### PR TITLE
wip: update(ci): make tests run a reusable workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 # 
 
-name: Test on Latest Dev Falco
+name: Test Dev Falco
 on:
   workflow_dispatch:
     inputs:
@@ -30,41 +30,9 @@ on:
 jobs:
   build:
     name: Run Tests on falcosecurity/falco image
-    runs-on: ubuntu-latest
-    container:
-      image: falcosecurity/falco:${{ github.event.inputs.version || 'master' }}
-    steps:
-      - name: Setup Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: '>=1.17.0'
-
-      - name: Checkout repo
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      # note: this converts the output of go test into a junit-compatible,
-      # which can later be processed by test-summary/action to upload
-      # a Markdown report on the GitHub Actions workflow.
-      - name: Install go-junit-report
-        run: |
-          go install github.com/jstemmer/go-junit-report/v2@latest
-  
-      - name: Generate test files
-        run: |
-          go generate ./...
-
-      - name: Run tests
-        run: |
-          ./build/falco.test -test.timeout=90s -test.v >> ./report.txt 2>&1 || true
-          ./build/falcoctl.test -test.timeout=90s -test.v >> ./report.txt 2>&1 || true
-          ./build/k8saudit.test -test.timeout=90s -test.v >> ./report.txt 2>&1 || true
-          cat ./report.txt | go-junit-report -set-exit-code > report.xml
-
-      - name: Test Summary
-        uses: test-summary/action@v2
-        with:
-          paths: "report.xml"
-          show: "all"
-        if: always() # note: upload the report even if tests fail
+    uses: ./.github/workflows/run_tests.yaml
+    with:
+      package: falco
+      summary_show: fail
+      container_image: falcosecurity/falco:${{ github.event.inputs.version || 'master' }}
+      # code_ref: main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 # 
 
-name: Test Dev Falco
+name: Run Tests
 on:
   workflow_dispatch:
     inputs:
@@ -28,11 +28,8 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  run-falco-tests:
     name: Run Tests on falcosecurity/falco image
     uses: ./.github/workflows/run_tests.yaml
     with:
-      package: falco
-      summary_show: fail
       container_image: falcosecurity/falco:${{ github.event.inputs.version || 'master' }}
-      # code_ref: main

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -1,0 +1,71 @@
+name: Run Tests
+
+on:
+  workflow_call:
+    inputs:
+      # empty (runs all packages), or one of the following: 'falco', 'falcoctl', 'k8saudit'
+      package:
+        required: false
+        type: string
+      # a valid git ref from falcosecurity/testing to run tests with
+      code_ref:
+        required: false
+        type: string
+      # one of the following, or a comma-separated list: 'all', 'none', 'pass', 'skip', or 'fail'
+      summary_show:
+        required: false
+        type: string
+      # a base container image to un the worflow into
+      container_image:
+        required: false
+        type: string
+
+jobs:
+  build:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ inputs.container_image || '' }}
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.17.0'
+
+      - name: Checkout falcosecurity/testing
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.code_ref || '' }}
+
+      # note: this converts the output of go test into a junit-compatible,
+      # which can later be processed by test-summary/action to upload
+      # a Markdown report on the GitHub Actions workflow.
+      - name: Install go-junit-report
+        run: |
+          go install github.com/jstemmer/go-junit-report/v2@latest
+
+      - name: Run Go Generate
+        run: |
+          go generate ./...
+      
+      - name: Run Tests (all packages)
+        if: inputs.package == ''
+        run: |
+          ./build/falco.test -test.timeout=90s -test.v >> ./report.txt 2>&1 || true
+          ./build/falcoctl.test -test.timeout=90s -test.v >> ./report.txt 2>&1 || true
+          ./build/k8saudit.test -test.timeout=90s -test.v >> ./report.txt 2>&1 || true
+          cat ./report.txt | go-junit-report -set-exit-code > report.xml
+
+      - name: Run Tests (single package)
+        if: inputs.package != ''
+        run: |
+          ./build/${{ inputs.package }}.test -test.timeout=90s -test.v >> ./report.txt 2>&1 || true
+          cat ./report.txt | go-junit-report -set-exit-code > report.xml
+
+      - name: Test Summary
+        uses: test-summary/action@v2
+        with:
+          paths: "report.xml"
+          show: ${{ inputs.summary_show || 'all' }}
+        if: always() # note: upload the report even if tests fail

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -7,18 +7,22 @@ on:
       package:
         required: false
         type: string
+        default: ''
       # a valid git ref from falcosecurity/testing to run tests with
       code_ref:
         required: false
         type: string
+        default: ''
       # one of the following, or a comma-separated list: 'all', 'none', 'pass', 'skip', or 'fail'
       summary_show:
         required: false
         type: string
+        default: 'all'
       # a base container image to un the worflow into
       container_image:
         required: false
         type: string
+        default: ''
 
 jobs:
   build:


### PR DESCRIPTION
This attempts isolating the logic required to run the test suite for all packages or single ones, with the purpose of having a reusable workflow invocable from other repositories.