### PR TITLE
update(tests/falco): skip tests requiring default config if file is not present

### DIFF
--- a/pkg/falco/tester.go
+++ b/pkg/falco/tester.go
@@ -40,8 +40,11 @@ const (
 	// DefaultMaxDuration is the default max duration of a Falco run
 	DefaultMaxDuration = time.Second * 30
 	//
-	// DefaultFalcoExecutable is the default path of the Falco executable
+	// DefaultExecutable is the default path of the Falco executable
 	DefaultExecutable = "/usr/bin/falco"
+	//
+	// DefaultConfig is the default path of the Falco config file
+	DefaultConfigFile = "/etc/falco/falco.yaml"
 )
 
 type testOptions struct {

--- a/tests/data/data.go
+++ b/tests/data/data.go
@@ -42,7 +42,11 @@ import (
 )
 
 const (
-	FalcoCodeVersion = "0.33.1"
+	// FalcoCodeVersion is a git tag used to pull the code of
+	// falcosecurity/falco and extract the test data files used in the
+	// legacy Python regression tests
+	FalcoCodeVersion = "0.34.1"
+	FalcoCodeDir     = "falco-" + FalcoCodeVersion
 )
 
 var (
@@ -205,15 +209,15 @@ func ListDirFiles(dirPath string, recursive bool) ([]string, error) {
 
 func DownloadAndListFalcoCodeFiles() ([]string, error) {
 	extractDir := DownloadDir
-	err := Download(FalcoCodeURL, DownloadDir+"/falco-code.zip")
+	err := Download(FalcoCodeURL, DownloadDir+"/"+FalcoCodeDir+".zip")
 	if err != nil {
 		return nil, err
 	}
-	err = Unzip(DownloadDir+"/falco-code.zip", extractDir)
+	err = Unzip(DownloadDir+"/"+FalcoCodeDir+".zip", extractDir)
 	if err != nil {
 		return nil, err
 	}
-	return ListDirFiles(extractDir+"/falco-0.33.1/", true)
+	return ListDirFiles(extractDir+"/"+FalcoCodeDir+"/", true)
 }
 
 func VarNameFromFilePath(path, prefix string) string {

--- a/tests/data/plugins/plugins.go
+++ b/tests/data/plugins/plugins.go
@@ -21,15 +21,12 @@ import "github.com/falcosecurity/testing/pkg/run"
 
 var K8SAuditPlugin = run.NewLocalFileAccessor(
 	"libk8saudit.so",
-	"/usr/share/falco/plugins/libk8saudit.so",
-)
+	"/usr/share/falco/plugins/libk8saudit.so")
 
 var CloudtrailPlugin = run.NewLocalFileAccessor(
 	"libcloudtrail.so",
-	"/usr/share/falco/plugins/libcloudtrail.so",
-)
+	"/usr/share/falco/plugins/libcloudtrail.so")
 
 var JSONPlugin = run.NewLocalFileAccessor(
 	"libjson.so",
-	"/usr/share/falco/plugins/libjson.so",
-)
+	"/usr/share/falco/plugins/libjson.so")

--- a/tests/data/rules/rules.go
+++ b/tests/data/rules/rules.go
@@ -22,10 +22,8 @@ import "github.com/falcosecurity/testing/pkg/run"
 
 var FalcoRules = run.NewLocalFileAccessor(
 	"falco_rules.yaml",
-	"/etc/falco/falco_rules.yaml",
-)
+	"/etc/falco/falco_rules.yaml")
 
 var K8SAuditRules = run.NewLocalFileAccessor(
 	" k8s_audit_rules.yaml",
-	"/etc/falco/k8s_audit_rules.yaml",
-)
+	"/etc/falco/k8s_audit_rules.yaml")

--- a/tests/falco/commands_test.go
+++ b/tests/falco/commands_test.go
@@ -42,8 +42,11 @@ import (
 //   -s, --stats-interval, -U, --unbuffered
 
 func TestFalco_Cmd_Version(t *testing.T) {
+	t.Parallel()
+	checkDefaultConfig(t)
 	runner := tests.NewFalcoExecutableRunner(t)
 	t.Run("text-output", func(t *testing.T) {
+		t.Parallel()
 		res := falco.Test(runner, falco.WithArgs("--version"))
 		assert.NoError(t, res.Err(), "%s", res.Stderr())
 		assert.Equal(t, res.ExitCode(), 0)
@@ -59,6 +62,7 @@ func TestFalco_Cmd_Version(t *testing.T) {
 			res.Stdout())
 	})
 	t.Run("json-output", func(t *testing.T) {
+		t.Parallel()
 		res := falco.Test(runner,
 			falco.WithArgs("--version"),
 			falco.WithOutputJSON(),
@@ -77,6 +81,8 @@ func TestFalco_Cmd_Version(t *testing.T) {
 }
 
 func TestFalco_Cmd_ListPlugins(t *testing.T) {
+	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithArgs("--list-plugins"),
@@ -105,6 +111,8 @@ func TestFalco_Cmd_ListPlugins(t *testing.T) {
 }
 
 func TestFalco_Cmd_PluginInfo(t *testing.T) {
+	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithArgs("--plugin-info=cloudtrail"),

--- a/tests/falco/legacy_test.go
+++ b/tests/falco/legacy_test.go
@@ -56,6 +56,7 @@ import (
 
 func TestFalco_Legacy_EngineVersionMismatch(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -70,6 +71,7 @@ func TestFalco_Legacy_EngineVersionMismatch(t *testing.T) {
 
 func TestFalco_Legacy_MacroOverriding(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithRules(rules.SingleRule, rules.OverrideMacro),
@@ -81,6 +83,7 @@ func TestFalco_Legacy_MacroOverriding(t *testing.T) {
 
 func TestFalco_Legacy_Endswith(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -97,6 +100,7 @@ func TestFalco_Legacy_Endswith(t *testing.T) {
 
 func TestFalco_Legacy_DisabledAndEnabledRules1(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithRules(rules.SingleRule),
@@ -147,6 +151,7 @@ func TestFalco_Legacy_StdoutOutputJsonStrict(t *testing.T) {
 
 func TestFalco_Legacy_ListAppendFalse(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithRules(rules.ListAppendFalse),
@@ -158,6 +163,7 @@ func TestFalco_Legacy_ListAppendFalse(t *testing.T) {
 
 func TestFalco_Legacy_MacroAppend(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -174,6 +180,7 @@ func TestFalco_Legacy_MacroAppend(t *testing.T) {
 
 func TestFalco_Legacy_ListSubstring(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithRules(rules.ListSubstring),
@@ -185,6 +192,7 @@ func TestFalco_Legacy_ListSubstring(t *testing.T) {
 
 func TestFalco_Legacy_InvalidNotArray(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -200,6 +208,7 @@ func TestFalco_Legacy_InvalidNotArray(t *testing.T) {
 
 func TestFalco_Legacy_InvalidEngineVersionNotNumber(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -215,6 +224,7 @@ func TestFalco_Legacy_InvalidEngineVersionNotNumber(t *testing.T) {
 
 func TestFalco_Legacy_InvalidOverwriteRuleMultipleDocs(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -231,6 +241,7 @@ func TestFalco_Legacy_InvalidOverwriteRuleMultipleDocs(t *testing.T) {
 
 func TestFalco_Legacy_DisabledRulesUsingSubstring(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithRules(rules.EmptyRules, rules.SingleRule),
@@ -243,6 +254,7 @@ func TestFalco_Legacy_DisabledRulesUsingSubstring(t *testing.T) {
 
 func TestFalco_Legacy_DetectSkipUnknownNoevt(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithRules(rules.SkipUnknownEvt),
@@ -254,6 +266,7 @@ func TestFalco_Legacy_DetectSkipUnknownNoevt(t *testing.T) {
 
 func TestFalco_Legacy_ListAppend(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -270,6 +283,7 @@ func TestFalco_Legacy_ListAppend(t *testing.T) {
 
 func TestFalco_Legacy_RuleAppendSkipped(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithMinRulePriority("ERROR"),
@@ -282,6 +296,7 @@ func TestFalco_Legacy_RuleAppendSkipped(t *testing.T) {
 
 func TestFalco_Legacy_SkipUnknownError(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -298,6 +313,7 @@ func TestFalco_Legacy_SkipUnknownError(t *testing.T) {
 
 func TestFalco_Legacy_MultipleRulesOverriding(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithRules(rules.SingleRule, rules.OverrideRule),
@@ -309,6 +325,7 @@ func TestFalco_Legacy_MultipleRulesOverriding(t *testing.T) {
 
 func TestFalco_Legacy_InvalidAppendMacro(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -331,6 +348,7 @@ func TestFalco_Legacy_InvalidAppendMacro(t *testing.T) {
 
 func TestFalco_Legacy_InvalidMissingListName(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -346,6 +364,7 @@ func TestFalco_Legacy_InvalidMissingListName(t *testing.T) {
 
 func TestFalco_Legacy_DisabledTagsB(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -376,6 +395,7 @@ func TestFalco_Legacy_DisabledTagsB(t *testing.T) {
 
 func TestFalco_Legacy_RunTagsC(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -406,6 +426,7 @@ func TestFalco_Legacy_RunTagsC(t *testing.T) {
 
 func TestFalco_Legacy_RunTagsAbc(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -436,6 +457,7 @@ func TestFalco_Legacy_RunTagsAbc(t *testing.T) {
 
 func TestFalco_Legacy_RuleAppend(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -452,6 +474,7 @@ func TestFalco_Legacy_RuleAppend(t *testing.T) {
 
 func TestFalco_Legacy_ListOverriding(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithRules(rules.SingleRule, rules.OverrideList),
@@ -463,6 +486,7 @@ func TestFalco_Legacy_ListOverriding(t *testing.T) {
 
 func TestFalco_Legacy_ListSubBare(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -479,6 +503,7 @@ func TestFalco_Legacy_ListSubBare(t *testing.T) {
 
 func TestFalco_Legacy_InvalidAppendMacroDangling(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -495,6 +520,7 @@ func TestFalco_Legacy_InvalidAppendMacroDangling(t *testing.T) {
 
 func TestFalco_Legacy_InvalidOverwriteMacroMultipleDocs(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -511,6 +537,7 @@ func TestFalco_Legacy_InvalidOverwriteMacroMultipleDocs(t *testing.T) {
 
 func TestFalco_Legacy_DisabledTagsA(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -541,6 +568,7 @@ func TestFalco_Legacy_DisabledTagsA(t *testing.T) {
 
 func TestFalco_Legacy_InvalidYamlParseError(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -556,6 +584,7 @@ func TestFalco_Legacy_InvalidYamlParseError(t *testing.T) {
 
 func TestFalco_Legacy_InvalidRuleWithoutOutput(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -572,6 +601,7 @@ func TestFalco_Legacy_InvalidRuleWithoutOutput(t *testing.T) {
 
 func TestFalco_Legacy_Syscalls(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -591,6 +621,7 @@ func TestFalco_Legacy_Syscalls(t *testing.T) {
 
 func TestFalco_Legacy_BuiltinRulesNoWarnings(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithCaptureFile(captures.Empty),
@@ -601,6 +632,7 @@ func TestFalco_Legacy_BuiltinRulesNoWarnings(t *testing.T) {
 
 func TestFalco_Legacy_RunTagsA(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -680,6 +712,7 @@ func TestFalco_Legacy_MonitorSyscallDropsThresholdOor(t *testing.T) {
 
 func TestFalco_Legacy_MultipleRulesSuppressInfo(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithMinRulePriority("WARNING"),
@@ -702,6 +735,7 @@ func TestFalco_Legacy_MultipleRulesSuppressInfo(t *testing.T) {
 
 func TestFalco_Legacy_ListSubMid(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -718,6 +752,7 @@ func TestFalco_Legacy_ListSubMid(t *testing.T) {
 
 func TestFalco_Legacy_InvalidListWithoutItems(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -734,6 +769,7 @@ func TestFalco_Legacy_InvalidListWithoutItems(t *testing.T) {
 
 func TestFalco_Legacy_DisabledRulesUsingEnabledFlag(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithRules(rules.SingleRuleEnabledFlag),
@@ -745,6 +781,7 @@ func TestFalco_Legacy_DisabledRulesUsingEnabledFlag(t *testing.T) {
 
 func TestFalco_Legacy_DisabledRuleUsingFalseEnabledFlagOnly(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithRules(rules.DisabledRuleUsingEnabledFlagOnly),
@@ -756,6 +793,7 @@ func TestFalco_Legacy_DisabledRuleUsingFalseEnabledFlagOnly(t *testing.T) {
 
 func TestFalco_Legacy_InvalidRuleOutput(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -790,6 +828,7 @@ func TestFalco_Legacy_FileOutputStrict(t *testing.T) {
 
 func TestFalco_Legacy_RunTagsBc(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -854,6 +893,7 @@ func TestFalco_Legacy_MonitorSyscallDropsThresholdNeg(t *testing.T) {
 
 func TestFalco_Legacy_MultipleRulesLastEmpty(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -870,6 +910,7 @@ func TestFalco_Legacy_MultipleRulesLastEmpty(t *testing.T) {
 
 func TestFalco_Legacy_ListSubWhitespace(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -886,6 +927,7 @@ func TestFalco_Legacy_ListSubWhitespace(t *testing.T) {
 
 func TestFalco_Legacy_InvalidMacroWithoutCondition(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -902,6 +944,7 @@ func TestFalco_Legacy_InvalidMacroWithoutCondition(t *testing.T) {
 
 func TestFalco_Legacy_CatchallOrder(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -920,6 +963,7 @@ func TestFalco_Legacy_CatchallOrder(t *testing.T) {
 
 func TestFalco_Legacy_ListSubFront(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -936,6 +980,7 @@ func TestFalco_Legacy_ListSubFront(t *testing.T) {
 
 func TestFalco_Legacy_ListOrder(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -952,6 +997,7 @@ func TestFalco_Legacy_ListOrder(t *testing.T) {
 
 func TestFalco_Legacy_InvalidMissingMacroName(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -967,6 +1013,7 @@ func TestFalco_Legacy_InvalidMissingMacroName(t *testing.T) {
 
 func TestFalco_Legacy_DisabledTagsAbc(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -997,6 +1044,7 @@ func TestFalco_Legacy_DisabledTagsAbc(t *testing.T) {
 
 func TestFalco_Legacy_SkipUnknownPrefix(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithRules(rules.SkipUnknownPrefix),
@@ -1024,6 +1072,7 @@ func TestFalco_Legacy_MonitorSyscallDropsLog(t *testing.T) {
 
 func TestFalco_Legacy_InvalidRuleAppendDangling(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1040,6 +1089,7 @@ func TestFalco_Legacy_InvalidRuleAppendDangling(t *testing.T) {
 
 func TestFalco_Legacy_InvalidOverwriteRule(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1057,6 +1107,7 @@ func TestFalco_Legacy_InvalidOverwriteRule(t *testing.T) {
 
 func TestFalco_Legacy_DisabledTagsC(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1087,6 +1138,7 @@ func TestFalco_Legacy_DisabledTagsC(t *testing.T) {
 
 func TestFalco_Legacy_RunTagsD(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1117,6 +1169,7 @@ func TestFalco_Legacy_RunTagsD(t *testing.T) {
 
 func TestFalco_Legacy_MacroAppendFalse(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithRules(rules.MacroAppendFalse),
@@ -1128,6 +1181,7 @@ func TestFalco_Legacy_MacroAppendFalse(t *testing.T) {
 
 func TestFalco_Legacy_InvalidAppendMacroMultipleDocs(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1144,6 +1198,7 @@ func TestFalco_Legacy_InvalidAppendMacroMultipleDocs(t *testing.T) {
 
 func TestFalco_Legacy_DisabledRules(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithRules(rules.EmptyRules, rules.SingleRule),
@@ -1156,6 +1211,7 @@ func TestFalco_Legacy_DisabledRules(t *testing.T) {
 
 func TestFalco_Legacy_MultipleRules(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1175,6 +1231,7 @@ func TestFalco_Legacy_MultipleRules(t *testing.T) {
 
 func TestFalco_Legacy_MultipleDocs(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1194,6 +1251,7 @@ func TestFalco_Legacy_MultipleDocs(t *testing.T) {
 
 func TestFalco_Legacy_NestedListOverriding(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithRules(rules.SingleRule, rules.OverrideNestedList),
@@ -1205,6 +1263,7 @@ func TestFalco_Legacy_NestedListOverriding(t *testing.T) {
 
 func TestFalco_Legacy_MacroOrder(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1221,6 +1280,7 @@ func TestFalco_Legacy_MacroOrder(t *testing.T) {
 
 func TestFalco_Legacy_InvalidAppendRuleWithoutCondition(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1237,6 +1297,7 @@ func TestFalco_Legacy_InvalidAppendRuleWithoutCondition(t *testing.T) {
 
 func TestFalco_Legacy_SkipUnknownUnspecError(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1286,6 +1347,7 @@ func TestFalco_Legacy_MonitorSyscallDropsExit(t *testing.T) {
 
 func TestFalco_Legacy_DisabledTagsAb(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1316,6 +1378,7 @@ func TestFalco_Legacy_DisabledTagsAb(t *testing.T) {
 
 func TestFalco_Legacy_RunTagsB(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1346,6 +1409,7 @@ func TestFalco_Legacy_RunTagsB(t *testing.T) {
 
 func TestFalco_Legacy_RuleAppendFalse(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithRules(rules.RuleAppendFalse),
@@ -1357,6 +1421,7 @@ func TestFalco_Legacy_RuleAppendFalse(t *testing.T) {
 
 func TestFalco_Legacy_RuleOrder(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1373,6 +1438,7 @@ func TestFalco_Legacy_RuleOrder(t *testing.T) {
 
 func TestFalco_Legacy_InvalidNotYaml(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1388,6 +1454,7 @@ func TestFalco_Legacy_InvalidNotYaml(t *testing.T) {
 
 func TestFalco_Legacy_InvalidOverwriteMacro(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1410,6 +1477,7 @@ func TestFalco_Legacy_InvalidOverwriteMacro(t *testing.T) {
 
 func TestFalco_Legacy_InvalidMissingRuleName(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1425,6 +1493,7 @@ func TestFalco_Legacy_InvalidMissingRuleName(t *testing.T) {
 
 func TestFalco_Legacy_RuleNamesWithSpaces(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1441,6 +1510,7 @@ func TestFalco_Legacy_RuleNamesWithSpaces(t *testing.T) {
 
 func TestFalco_Legacy_MultipleRulesFirstEmpty(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1475,6 +1545,7 @@ func TestFalco_Legacy_ProgramOutputStrict(t *testing.T) {
 
 func TestFalco_Legacy_InvalidAppendRule(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1492,6 +1563,7 @@ func TestFalco_Legacy_InvalidAppendRule(t *testing.T) {
 
 func TestFalco_Legacy_InvalidAppendRuleMultipleDocs(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1508,6 +1580,7 @@ func TestFalco_Legacy_InvalidAppendRuleMultipleDocs(t *testing.T) {
 
 func TestFalco_Legacy_DisabledAndEnabledRules2(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithRules(rules.SingleRule),
@@ -1522,6 +1595,7 @@ func TestFalco_Legacy_DisabledAndEnabledRules2(t *testing.T) {
 
 func TestFalco_Legacy_RunTagsAb(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1552,6 +1626,7 @@ func TestFalco_Legacy_RunTagsAb(t *testing.T) {
 
 func TestFalco_Legacy_ValidateSkipUnknownNoevt(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1568,6 +1643,7 @@ func TestFalco_Legacy_ValidateSkipUnknownNoevt(t *testing.T) {
 
 func TestFalco_Legacy_ListSubEnd(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1584,6 +1660,7 @@ func TestFalco_Legacy_ListSubEnd(t *testing.T) {
 
 func TestFalco_Legacy_InvalidArrayItemNotObject(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1599,6 +1676,7 @@ func TestFalco_Legacy_InvalidArrayItemNotObject(t *testing.T) {
 
 func TestFalco_Legacy_InvalidListAppendDangling(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1615,6 +1693,7 @@ func TestFalco_Legacy_InvalidListAppendDangling(t *testing.T) {
 
 func TestFalco_Legacy_RuleExceptionSecondItem(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1631,6 +1710,7 @@ func TestFalco_Legacy_RuleExceptionSecondItem(t *testing.T) {
 
 func TestFalco_Legacy_RuleExceptionAppendMultipleValues(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1647,6 +1727,7 @@ func TestFalco_Legacy_RuleExceptionAppendMultipleValues(t *testing.T) {
 
 func TestFalco_Legacy_RuleExceptionAppendComp(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1663,6 +1744,7 @@ func TestFalco_Legacy_RuleExceptionAppendComp(t *testing.T) {
 
 func TestFalco_Legacy_RuleExceptionSingleField(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1679,6 +1761,7 @@ func TestFalco_Legacy_RuleExceptionSingleField(t *testing.T) {
 
 func TestFalco_Legacy_RuleExceptionNewAppendNoField(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1695,6 +1778,7 @@ func TestFalco_Legacy_RuleExceptionNewAppendNoField(t *testing.T) {
 
 func TestFalco_Legacy_RuleExceptionAppendOneValue(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1711,6 +1795,7 @@ func TestFalco_Legacy_RuleExceptionAppendOneValue(t *testing.T) {
 
 func TestFalco_Legacy_RuleExceptionQuoted(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1727,6 +1812,7 @@ func TestFalco_Legacy_RuleExceptionQuoted(t *testing.T) {
 
 func TestFalco_Legacy_RuleExceptionAppendThirdItem(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1743,6 +1829,7 @@ func TestFalco_Legacy_RuleExceptionAppendThirdItem(t *testing.T) {
 
 func TestFalco_Legacy_RuleExceptionSingleFieldAppend(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1759,6 +1846,7 @@ func TestFalco_Legacy_RuleExceptionSingleFieldAppend(t *testing.T) {
 
 func TestFalco_Legacy_RuleExceptionNewSingleFieldAppend(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1775,6 +1863,7 @@ func TestFalco_Legacy_RuleExceptionNewSingleFieldAppend(t *testing.T) {
 
 func TestFalco_Legacy_RuleExceptionUnknownFields(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1791,6 +1880,7 @@ func TestFalco_Legacy_RuleExceptionUnknownFields(t *testing.T) {
 
 func TestFalco_Legacy_RuleExceptionSecondValue(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1807,6 +1897,7 @@ func TestFalco_Legacy_RuleExceptionSecondValue(t *testing.T) {
 
 func TestFalco_Legacy_RuleExceptionValuesList(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1823,6 +1914,7 @@ func TestFalco_Legacy_RuleExceptionValuesList(t *testing.T) {
 
 func TestFalco_Legacy_RuleExceptionAppendFieldsValuesLenMismatch(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1839,6 +1931,7 @@ func TestFalco_Legacy_RuleExceptionAppendFieldsValuesLenMismatch(t *testing.T) {
 
 func TestFalco_Legacy_RuleExceptionAppendItemNotInRule(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1855,6 +1948,7 @@ func TestFalco_Legacy_RuleExceptionAppendItemNotInRule(t *testing.T) {
 
 func TestFalco_Legacy_RuleExceptionThirdItem(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1871,6 +1965,7 @@ func TestFalco_Legacy_RuleExceptionThirdItem(t *testing.T) {
 
 func TestFalco_Legacy_RuleExceptionNoFields(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1887,6 +1982,7 @@ func TestFalco_Legacy_RuleExceptionNoFields(t *testing.T) {
 
 func TestFalco_Legacy_RuleExceptionAppendNoName(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1902,6 +1998,7 @@ func TestFalco_Legacy_RuleExceptionAppendNoName(t *testing.T) {
 
 func TestFalco_Legacy_RuleExceptionCompsFieldsLenMismatch(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1918,6 +2015,7 @@ func TestFalco_Legacy_RuleExceptionCompsFieldsLenMismatch(t *testing.T) {
 
 func TestFalco_Legacy_RuleExceptionNoValues(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1934,6 +2032,7 @@ func TestFalco_Legacy_RuleExceptionNoValues(t *testing.T) {
 
 func TestFalco_Legacy_RuleExceptionAppendSecondValue(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1950,6 +2049,7 @@ func TestFalco_Legacy_RuleExceptionAppendSecondValue(t *testing.T) {
 
 func TestFalco_Legacy_RuleExceptionNoName(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1965,6 +2065,7 @@ func TestFalco_Legacy_RuleExceptionNoName(t *testing.T) {
 
 func TestFalco_Legacy_RuleExceptionComp(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1981,6 +2082,7 @@ func TestFalco_Legacy_RuleExceptionComp(t *testing.T) {
 
 func TestFalco_Legacy_RuleExceptionValuesListref(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -1997,6 +2099,7 @@ func TestFalco_Legacy_RuleExceptionValuesListref(t *testing.T) {
 
 func TestFalco_Legacy_RuleExceptionNewSecondFieldAppend(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2013,6 +2116,7 @@ func TestFalco_Legacy_RuleExceptionNewSecondFieldAppend(t *testing.T) {
 
 func TestFalco_Legacy_RuleExceptionUnknownComp(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2029,6 +2133,7 @@ func TestFalco_Legacy_RuleExceptionUnknownComp(t *testing.T) {
 
 func TestFalco_Legacy_RuleExceptionFieldsValuesLenMismatch(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2045,6 +2150,7 @@ func TestFalco_Legacy_RuleExceptionFieldsValuesLenMismatch(t *testing.T) {
 
 func TestFalco_Legacy_RuleExceptionOneValue(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2061,6 +2167,7 @@ func TestFalco_Legacy_RuleExceptionOneValue(t *testing.T) {
 
 func TestFalco_Legacy_RuleExceptionAppendSecondItem(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2077,6 +2184,7 @@ func TestFalco_Legacy_RuleExceptionAppendSecondItem(t *testing.T) {
 
 func TestFalco_Legacy_RuleExceptionValuesListrefNoparens(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2093,6 +2201,7 @@ func TestFalco_Legacy_RuleExceptionValuesListrefNoparens(t *testing.T) {
 
 func TestFalco_Legacy_ReadSensitiveFileUntrusted(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2109,6 +2218,7 @@ func TestFalco_Legacy_ReadSensitiveFileUntrusted(t *testing.T) {
 
 func TestFalco_Legacy_KernelUpgrade(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2124,6 +2234,7 @@ func TestFalco_Legacy_KernelUpgrade(t *testing.T) {
 
 func TestFalco_Legacy_CreateFilesBelowDev(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2140,6 +2251,7 @@ func TestFalco_Legacy_CreateFilesBelowDev(t *testing.T) {
 
 func TestFalco_Legacy_ReadSensitiveFileAfterStartup(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2157,6 +2269,7 @@ func TestFalco_Legacy_ReadSensitiveFileAfterStartup(t *testing.T) {
 
 func TestFalco_Legacy_RunShellUntrusted(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2173,6 +2286,7 @@ func TestFalco_Legacy_RunShellUntrusted(t *testing.T) {
 
 func TestFalco_Legacy_ChangeThreadNamespace(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2189,6 +2303,7 @@ func TestFalco_Legacy_ChangeThreadNamespace(t *testing.T) {
 
 func TestFalco_Legacy_MkdirBinaryDirs(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2205,6 +2320,7 @@ func TestFalco_Legacy_MkdirBinaryDirs(t *testing.T) {
 
 func TestFalco_Legacy_SystemBinariesNetworkActivity(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2221,6 +2337,7 @@ func TestFalco_Legacy_SystemBinariesNetworkActivity(t *testing.T) {
 
 func TestFalco_Legacy_WriteRpmDatabase(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2237,6 +2354,7 @@ func TestFalco_Legacy_WriteRpmDatabase(t *testing.T) {
 
 func TestFalco_Legacy_DockerCompose(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2254,6 +2372,7 @@ func TestFalco_Legacy_DockerCompose(t *testing.T) {
 
 func TestFalco_Legacy_CurlUninstall(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2269,6 +2388,7 @@ func TestFalco_Legacy_CurlUninstall(t *testing.T) {
 
 func TestFalco_Legacy_DhcpclientRenew(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2284,6 +2404,7 @@ func TestFalco_Legacy_DhcpclientRenew(t *testing.T) {
 
 func TestFalco_Legacy_StagingWorker(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2299,6 +2420,7 @@ func TestFalco_Legacy_StagingWorker(t *testing.T) {
 
 func TestFalco_Legacy_DbProgramSpawnedProcess(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2316,6 +2438,7 @@ func TestFalco_Legacy_DbProgramSpawnedProcess(t *testing.T) {
 
 func TestFalco_Legacy_UserMgmtBinaries(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2333,6 +2456,7 @@ func TestFalco_Legacy_UserMgmtBinaries(t *testing.T) {
 
 func TestFalco_Legacy_Exim4(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2348,6 +2472,7 @@ func TestFalco_Legacy_Exim4(t *testing.T) {
 
 func TestFalco_Legacy_WriteEtc(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2364,6 +2489,7 @@ func TestFalco_Legacy_WriteEtc(t *testing.T) {
 
 func TestFalco_Legacy_StagingCollector(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2379,6 +2505,7 @@ func TestFalco_Legacy_StagingCollector(t *testing.T) {
 
 func TestFalco_Legacy_ContainerPrivileged(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2396,6 +2523,7 @@ func TestFalco_Legacy_ContainerPrivileged(t *testing.T) {
 
 func TestFalco_Legacy_ContainerSensitiveMount(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2413,6 +2541,7 @@ func TestFalco_Legacy_ContainerSensitiveMount(t *testing.T) {
 
 func TestFalco_Legacy_WriteBinaryDir(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2429,6 +2558,7 @@ func TestFalco_Legacy_WriteBinaryDir(t *testing.T) {
 
 func TestFalco_Legacy_CurlInstall(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2444,6 +2574,7 @@ func TestFalco_Legacy_CurlInstall(t *testing.T) {
 
 func TestFalco_Legacy_StagingDb(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2459,6 +2590,7 @@ func TestFalco_Legacy_StagingDb(t *testing.T) {
 
 func TestFalco_Legacy_ModifyBinaryDirs(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2475,6 +2607,7 @@ func TestFalco_Legacy_ModifyBinaryDirs(t *testing.T) {
 
 func TestFalco_Legacy_NonSudoSetuid(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2491,6 +2624,7 @@ func TestFalco_Legacy_NonSudoSetuid(t *testing.T) {
 
 func TestFalco_Legacy_GitPush(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2508,6 +2642,7 @@ func TestFalco_Legacy_KubeDemo(t *testing.T) {
 	// todo(jasondellaluce): this is very heavy and slow, let's skip it for now
 	t.Skip()
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithMaxDuration(90*time.Second),
@@ -2524,6 +2659,7 @@ func TestFalco_Legacy_KubeDemo(t *testing.T) {
 
 func TestFalco_Legacy_FalcoEventGenerator(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2555,6 +2691,7 @@ func TestFalco_Legacy_FalcoEventGenerator(t *testing.T) {
 
 func TestFalco_Legacy_SystemUserInteractive(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2572,6 +2709,7 @@ func TestFalco_Legacy_SystemUserInteractive(t *testing.T) {
 
 func TestFalco_Legacy_DetectCounts(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2600,6 +2738,7 @@ func TestFalco_Legacy_DetectCounts(t *testing.T) {
 
 func TestFalco_Legacy_RuleNamesWithRegexChars(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2617,6 +2756,7 @@ func TestFalco_Legacy_RuleNamesWithRegexChars(t *testing.T) {
 
 func TestFalco_Legacy_JsonOutputNoOutputProperty(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2634,6 +2774,7 @@ func TestFalco_Legacy_JsonOutputNoOutputProperty(t *testing.T) {
 
 func TestFalco_Legacy_JsonOutputNoTagsProperty(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2651,6 +2792,7 @@ func TestFalco_Legacy_JsonOutputNoTagsProperty(t *testing.T) {
 
 func TestFalco_Legacy_JsonOutputEmptyTagsProperty(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2668,6 +2810,7 @@ func TestFalco_Legacy_JsonOutputEmptyTagsProperty(t *testing.T) {
 
 func TestFalco_Legacy_RulesDirectory(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2687,6 +2830,7 @@ func TestFalco_Legacy_RulesDirectory(t *testing.T) {
 
 func TestFalco_Legacy_EnabledRuleUsingFalseEnabledFlagOnly(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2704,6 +2848,7 @@ func TestFalco_Legacy_EnabledRuleUsingFalseEnabledFlagOnly(t *testing.T) {
 
 func TestFalco_Legacy_NullOutputField(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2721,6 +2866,7 @@ func TestFalco_Legacy_NullOutputField(t *testing.T) {
 
 func TestFalco_Legacy_InOperatorNetmasks(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2737,6 +2883,7 @@ func TestFalco_Legacy_InOperatorNetmasks(t *testing.T) {
 
 func TestFalco_Legacy_TimeIso8601(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2756,6 +2903,7 @@ func TestFalco_Legacy_TimeIso8601(t *testing.T) {
 
 func TestFalco_Legacy_TestWarnings(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2854,6 +3002,7 @@ func TestFalco_Legacy_GrpcUnixSocketOutputs(t *testing.T) {
 
 func TestFalco_Legacy_NoPluginsUnknownSource(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),
@@ -2870,6 +3019,7 @@ func TestFalco_Legacy_NoPluginsUnknownSource(t *testing.T) {
 
 func TestFalco_Legacy_NoPluginsUnknownSourceRuleException(t *testing.T) {
 	t.Parallel()
+	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithOutputJSON(),

--- a/tests/falco/miscs_test.go
+++ b/tests/falco/miscs_test.go
@@ -18,6 +18,7 @@ limitations under the License.
 package testfalco
 
 import (
+	"os"
 	"testing"
 
 	"github.com/falcosecurity/testing/pkg/falco"
@@ -45,6 +46,12 @@ import (
 //   - collection of live events with kmod, bpf, modern-bpf, gvisor, userspace
 //   - collection of live events with multiple event sources active at the same
 //   - stress test with event generator, checking memory usage and event drops
+
+func checkDefaultConfig(t *testing.T) {
+	if _, err := os.Stat(falco.DefaultConfigFile); err != nil {
+		t.Skipf("could not find default Falco config: %s", err.Error())
+	}
+}
 
 func TestFalco_Miscs_StartupFail(t *testing.T) {
 	runner := tests.NewFalcoExecutableRunner(t)


### PR DESCRIPTION
Most of the Falco tests are meant to work on a Falco installation, specially looking for a default config file (`/etc/falco/falco.yaml`). During local development, this can cause trouble when specifying a custom executable path but when the default config file cannot be found.

This PR mitigates the problem towards a better UX when running tests locally for development purposes, by skipping all tests for which a Falco binary is specified but the default config file cannot be found (only when required).