### PR TITLE
update(tests): handle falco static builds

### DIFF
--- a/tests/falco/commands_test.go
+++ b/tests/falco/commands_test.go
@@ -32,7 +32,7 @@ import (
 
 // todo(jasondellaluce): implement tests for the non-covered Falco cmds/args:
 // Commands printing information:
-//   -h, --help, --support, -i, -L, -l, --list, --list-syscall-events,
+//   -h, --help, --support, -l, --list, --list-syscall-events,
 //   --markdown, -N, --gvisor-generate-config, --page-size
 // Metadata collection and container runtimes:
 //   --cri, --disable-cri-async, -k, --k8s-api, -K, --k8s-api-cert, --k8s-node, -m, --mesos-api
@@ -86,6 +86,7 @@ func TestFalco_Cmd_Version(t *testing.T) {
 func TestFalco_Cmd_ListPlugins(t *testing.T) {
 	t.Parallel()
 	checkDefaultConfig(t)
+	checkNotStaticExecutable(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithArgs("--list-plugins"),
@@ -116,6 +117,7 @@ func TestFalco_Cmd_ListPlugins(t *testing.T) {
 func TestFalco_Cmd_PluginInfo(t *testing.T) {
 	t.Parallel()
 	checkDefaultConfig(t)
+	checkNotStaticExecutable(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
 		falco.WithArgs("--plugin-info=cloudtrail"),

--- a/tests/falco/miscs_test.go
+++ b/tests/falco/miscs_test.go
@@ -47,9 +47,18 @@ import (
 //   - collection of live events with multiple event sources active at the same
 //   - stress test with event generator, checking memory usage and event drops
 
+// checkDefaultConfig skips a test if the default configuration filepath
+// is not available in the local filesystem.
 func checkDefaultConfig(t *testing.T) {
 	if _, err := os.Stat(falco.DefaultConfigFile); err != nil {
 		t.Skipf("could not find default Falco config: %s", err.Error())
+	}
+}
+
+// checkNotStaticExecutable is Falco executables use a static binary build.
+func checkNotStaticExecutable(t *testing.T) {
+	if tests.IsStaticFalcoExecutable() {
+		t.Skipf("test not available for static Falco builds")
 	}
 }
 

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -30,24 +30,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var falcoStatic = false
 var falcoBinary = falco.DefaultExecutable
 var falcoctlBinary = falcoctl.DefaultLocalExecutable
 
 func init() {
+	flag.BoolVar(&falcoStatic, "falco-static", falcoStatic, "True if the Falco executable is from a static build")
 	flag.StringVar(&falcoBinary, "falco-binary", falcoBinary, "Falco executable binary path")
 	flag.StringVar(&falcoctlBinary, "falcoctl-binary", falcoctlBinary, "falcoctl executable binary path")
 	logrus.SetLevel(logrus.DebugLevel)
 	logrus.SetFormatter(&logrus.JSONFormatter{})
 }
 
-// NewFalcoctlExecutableRunner returns an executable runner for Falco
+// NewFalcoExecutableRunner returns an executable runner for Falco.
 func NewFalcoExecutableRunner(t *testing.T) run.Runner {
 	runner, err := run.NewExecutableRunner(falcoBinary)
 	require.Nil(t, err)
 	return runner
 }
 
-// NewFalcoctlExecutableRunner returns an executable runner for falcoctl
+// NewFalcoctlExecutableRunner returns an executable runner for falcoctl.
 func NewFalcoctlExecutableRunner(t *testing.T) run.Runner {
 	if _, err := os.Stat(falcoctlBinary); err == nil {
 		runner, err := run.NewExecutableRunner(falcoctlBinary)
@@ -73,4 +75,9 @@ func IsInContainer() bool {
 		return true
 	}
 	return false
+}
+
+// IsStaticFalcoExecutable returns true if Falco executables use a static build.
+func IsStaticFalcoExecutable() bool {
+	return falcoStatic
 }


### PR DESCRIPTION
Static Falco builds can't load plugins from dynamic libraries currently, so this PR adds an option that allows skipping incompatible tests.