### PR TITLE
fix: adapt tests to falco dev

### DIFF
--- a/tests/data/outputs/events.txt
+++ b/tests/data/outputs/events.txt
@@ -1,1 +1,1 @@
-sendfile,recvfrom,readv,sendto,send,read,recvmmsg,write,recvmsg,pwrite,sendmmsg,sendmsg,pread,writev,recv,pwritev,preadv
+pread,preadv,pwrite,pwritev,read,readv,recv,recvmmsg,send,sendfile,sendmmsg,write,writev

--- a/tests/falco/commands_test.go
+++ b/tests/falco/commands_test.go
@@ -151,7 +151,7 @@ func TestFalco_Print_IgnoredEvents(t *testing.T) {
 		runner,
 		falco.WithArgs("-i"),
 	)
-	assert.Contains(t, res.Stdout(), "Ignored I/O syscall(s)")
+	assert.Contains(t, res.Stdout(), "Ignored syscall(s)")
 	for _, event := range events {
 		assert.Contains(t, res.Stdout(), event)
 	}


### PR DESCRIPTION
Adapts the tests to the latest Falco dev commit hash: https://github.com/falcosecurity/falco/commit/2818f0906e991d7ce9d7874a809bab8fcde120f9