### PR TITLE
chore(run) Update docker dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/falcosecurity/testing
 go 1.17
 
 require (
-	github.com/docker/docker v20.10.23+incompatible
+	github.com/docker/docker v24.0.3+incompatible
 	github.com/falcosecurity/client-go v0.5.1
 	github.com/iancoleman/strcase v0.2.0
 	github.com/sirupsen/logrus v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
 github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v20.10.23+incompatible h1:1ZQUUYAdh+oylOT85aA2ZcfRp22jmLhoaEcVEfK8dyA=
-github.com/docker/docker v20.10.23+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v24.0.3+incompatible h1:Kz/tcUmXhIojEivEoPcRWzL01tVRek7Th15/8BsRPWw=
+github.com/docker/docker v24.0.3+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=

--- a/pkg/run/docker.go
+++ b/pkg/run/docker.go
@@ -143,7 +143,7 @@ func (d *dockerRunner) withClient(ctx context.Context, do func(*client.Client) e
 }
 
 func (d *dockerRunner) createContainer(ctx context.Context, cli *client.Client, opts *runOpts) (id string, err error) {
-	var resp container.ContainerCreateCreatedBody
+	var resp container.CreateResponse
 	var env []string
 	for k, v := range opts.envVars {
 		env = append(env, fmt.Sprintf(`%s=%s`, k, v))
@@ -184,7 +184,7 @@ func (d *dockerRunner) stopContainer(cli *client.Client, containerID string) err
 	// note: the context's deadline may be done, but we still want to wait
 	ctx := context.Background()
 	logrus.WithField("containerID", containerID).Debugf("stopping docker container")
-	return cli.ContainerStop(ctx, containerID, nil)
+	return cli.ContainerStop(ctx, containerID, container.StopOptions{})
 }
 
 func (d *dockerRunner) copyFilesArchive(ctx context.Context, cli *client.Client, containerID string, files []FileAccessor) error {


### PR DESCRIPTION
Upgrade docker dependency to match version required by [falcoctl](https://github.com/falcosecurity/falcoctl). 
This way both package are compatible with each other again.

Fixes #17