### PR TITLE
New/rule matching tests

### DIFF
--- a/tests/data/configs/configs.go
+++ b/tests/data/configs/configs.go
@@ -420,3 +420,24 @@ program_output:
   enabled: false
 `,
 )
+
+var RuleMatchingFirst = run.NewStringFileAccessor(
+	"rule_matching_first.yaml",
+	`
+rule_matching: first
+  `,
+)
+
+var RuleMatchingAll = run.NewStringFileAccessor(
+	"rule_matching_all.yaml",
+	`
+rule_matching: all
+  `,
+)
+
+var RuleMatchingWrongValue = run.NewStringFileAccessor(
+	"rule_matching_wrong_value.yaml",
+	`
+rule_matching: test
+  `,
+)

--- a/tests/data/rules/falco.go
+++ b/tests/data/rules/falco.go
@@ -1323,3 +1323,23 @@ var TaggedRules = run.NewStringFileAccessor(
   priority: WARNING
 `,
 )
+
+var ShadowingRules = run.NewStringFileAccessor(
+	"shadowing_rules.yaml",
+	`
+- macro: open_read
+  condition: evt.type in (open,openat,openat2) and evt.is_open_read=true and fd.typechar='f'
+
+- rule: open_1
+  desc: open one
+  condition: open_read and fd.name=/etc/shadow and proc.name=cat
+  output: Open one (file=%fd.name)
+  priority: WARNING
+
+- rule: open_2
+  desc: open two
+  condition: open_read and fd.name=/etc/shadow and proc.name=cat
+  output: Open two (file=%fd.name)
+  priority: WARNING
+  `,
+)

--- a/tests/falco/config_test.go
+++ b/tests/falco/config_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+package testfalco
+
+import (
+	"testing"
+
+	"github.com/falcosecurity/testing/pkg/falco"
+	"github.com/falcosecurity/testing/tests"
+	"github.com/falcosecurity/testing/tests/data/captures"
+	"github.com/falcosecurity/testing/tests/data/configs"
+	"github.com/falcosecurity/testing/tests/data/rules"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFalco_Config_RuleMatchingFirst(t *testing.T) {
+	t.Parallel()
+	res := falco.Test(
+		tests.NewFalcoExecutableRunner(t),
+		falco.WithRules(rules.ShadowingRules),
+		falco.WithConfig(configs.RuleMatchingFirst),
+		falco.WithCaptureFile(captures.TracesPositiveReadSensitiveFileUntrusted),
+		falco.WithOutputJSON(),
+	)
+	assert.NoError(t, res.Err(), "%s", res.Stderr())
+	assert.Equal(t, 0, res.ExitCode())
+	assert.Equal(t, 1, res.Detections().Count())
+	assert.Equal(t, 1, res.Detections().OfRule("open_1").Count())
+}
+
+func TestFalco_Config_RuleMatchingAll(t *testing.T) {
+	t.Parallel()
+	res := falco.Test(
+		tests.NewFalcoExecutableRunner(t),
+		falco.WithRules(rules.ShadowingRules),
+		falco.WithConfig(configs.RuleMatchingAll),
+		falco.WithCaptureFile(captures.TracesPositiveReadSensitiveFileUntrusted),
+		falco.WithOutputJSON(),
+	)
+	assert.NoError(t, res.Err(), "%s", res.Stderr())
+	assert.Equal(t, 0, res.ExitCode())
+	assert.Equal(t, 2, res.Detections().Count())
+	assert.Equal(t, 1, res.Detections().OfRule("open_1").Count())
+	assert.Equal(t, 1, res.Detections().OfRule("open_2").Count())
+}
+
+func TestFalco_Config_RuleMatchingWrongValue(t *testing.T) {
+	t.Parallel()
+	res := falco.Test(
+		tests.NewFalcoExecutableRunner(t),
+		falco.WithRules(rules.ShadowingRules),
+		falco.WithConfig(configs.RuleMatchingWrongValue),
+		falco.WithCaptureFile(captures.TracesPositiveReadSensitiveFileUntrusted),
+		falco.WithOutputJSON(),
+	)
+	assert.NotNil(t, res.Stderr())
+	assert.Error(t, res.Err(), "%s", res.Stderr())
+	assert.Contains(t, res.Stderr(), "Unknown rule matching strategy")
+	assert.Equal(t, 1, res.ExitCode())
+}


### PR DESCRIPTION
This PR introduces testing for rule matching strategy configuration key. 
For further details, please refer to https://github.com/falcosecurity/falco/pull/2705