### PR TITLE
fix(falco/legacy_test.go): change expected detections in `TestFalco_Legacy_RunShellUntrusted`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,49 @@ This testing suite is implemented in Go, and Go is the only dependency required 
 Tests are defined as code, and as such the artifact released with the testing suite is the code itself.
 
 First, you need to run `go generate`. This will generate part of the testing code and date required by the suite.
+
 ```
 go generate ./...
 ```
 
 After this, the `build` directory will be created and will contain the testing binaries and the supporting test files.
+
 ```bash
 build/falco.test # run this to launch tests on Falco
 build/falcoctl.test # run this to launch tests on falctocl
 build/k8saudit.test # run this to launch tests on the k8saudit plugin
 ```
 
+You can provide custom options to the testing binaries, like a custom path to the Falco executable. You just need to specify the `-falco-binary` option followed by the path:
+
+```bash
+build/falco.test -falco-binary <path_to_falco>
+```
+
+You could also run a single test with the `-test.run` option:
+
+```bash
+build/falco.test -test.run 'TestFalco_Legacy_WriteBinaryDir'
+```
+
+To check all other options use the `--help` flag.
+
+## Keep tests updated with the latest Falco version
+
+Some of these tests might become incompatible with a new Falco version, for example after a fix an old scap-file could trigger more rules than the ones expected or maybe the rule is no more triggered for a valid reason.
+
+Falco CI runs these tests so we need to fix them before merging the new Falco version upstream. This is the usual flow to follow:
+
+1. Face a test failure in a pull request on the Falco repository (or detect the failure locally running Falco dev against this repo).
+2. Understand why these tests are failing, if there are no regressions and the Falco behavior is incompatible with actual tests, we change them accordingly.
+3. Open a pull request against this repo with the necessary changes.
+4. Once the pull request is merged use the derived commit to bump the submodule in the Falco repository.
+From the Falco source directory:
+
+ ```bash
+ cd submodules/falcosecurity-testing
+ git fetch
+ git merge origin/main # or git checkout <specific-commit>
+ ```
+
+5. Commit these changes in the same pull request with the new Falco version that caused test failures. Now tests should pass.

--- a/tests/falco/legacy_test.go
+++ b/tests/falco/legacy_test.go
@@ -2302,9 +2302,9 @@ func TestFalco_Legacy_RunShellUntrusted(t *testing.T) {
 		falco.WithArgs("-o", "json_include_output_property=false"),
 		falco.WithArgs("-o", "json_include_tags_property=false"),
 	)
-	assert.NotZero(t, res.Detections().Count())
-	assert.NotZero(t, res.Detections().OfPriority("DEBUG").Count())
-	assert.Equal(t, 1, res.Detections().OfRule("Run shell untrusted").Count())
+	assert.Zero(t, res.Detections().Count())
+	assert.Zero(t, res.Detections().OfPriority("DEBUG").Count())
+	assert.Equal(t, 0, res.Detections().OfRule("Run shell untrusted").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
 	assert.Equal(t, 0, res.ExitCode())
 }


### PR DESCRIPTION
After this commit in Falcosecurity/libs (https://github.com/falcosecurity/libs/commit/06289ec65d665760992772266ea993557de40d04) the behavior of `TestFalco_Legacy_RunShellUntrusted` should change.

Before this commit the rule `Run shell untrusted` was triggered with this scap-file `/traces-positive/run-shell-untrusted.scap` because this condition `proc.pname exists` was satisfied. The event number that triggered the rule was `432`. Analyzing the scap-file we can notice that the `proc.pname` associated with this event refers to an invalid thread (so a thread created by us and not really captured on the system). After the aforementioned commit invalid threads are no more considered valid parents because they carry unreliable information for this reason this rule won't trigger anymore because the `proc.pname`  will be `<NA>`

