### PR TITLE
new: add some tests to the Falco-driver-loader

### DIFF
--- a/pkg/falco/tester_options.go
+++ b/pkg/falco/tester_options.go
@@ -113,12 +113,10 @@ func WithCaptureFile(f run.FileAccessor) TestOption {
 	}
 }
 
-// WithMaxDuration runs Falco with a maximum duration through the `-M` option.
-func WithMaxDuration(duration time.Duration) TestOption {
+// WithContextDeadline runs Falco with a maximum context deadline.
+func WithContextDeadline(duration time.Duration) TestOption {
 	return func(o *testOptions) {
 		o.duration = duration
-		o.args = removeFromArgs(o.args, "-M", 1)
-		o.args = append(o.args, "-M", fmt.Sprintf("%d", int64(duration.Seconds())))
 	}
 }
 
@@ -151,4 +149,12 @@ func WithEnvVars(vars map[string]string) TestOption {
 // WithContext runs Falco with a given context.
 func WithContext(ctx context.Context) TestOption {
 	return func(o *testOptions) { o.ctx = ctx }
+}
+
+// WithStopAfter tells Falco to stop after 'duration' with the `-M` option.
+func WithStopAfter(duration time.Duration) TestOption {
+	return func(o *testOptions) {
+		o.args = removeFromArgs(o.args, "-M", 1)
+		o.args = append(o.args, "-M", fmt.Sprintf("%d", int64(duration.Seconds())))
+	}
 }

--- a/pkg/falcodriverloader/tester.go
+++ b/pkg/falcodriverloader/tester.go
@@ -1,0 +1,90 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+package falcodriverloader
+
+import (
+	"bytes"
+	"context"
+	"time"
+
+	"github.com/falcosecurity/testing/pkg/run"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// DefaultMaxDuration is the default max duration of a falco-driver-loader run
+	DefaultMaxDuration = time.Second * 30
+	//
+	// DefaultExecutable is the default path of the falco-driver-loader executable
+	// when installed from a Falco package
+	DefaultExecutable = "/usr/bin/falco-driver-loader"
+)
+
+type testOptions struct {
+	workdir  string
+	err      error
+	args     []string
+	duration time.Duration
+	files    []run.FileAccessor
+}
+
+// TestOutput is the output of a falco-driver-loader test run
+type TestOutput struct {
+	opts   *testOptions
+	err    error
+	stdout bytes.Buffer
+	stderr bytes.Buffer
+}
+
+// TestOption is an option for testing falco-driver-loader
+type TestOption func(*testOptions)
+
+// Test runs a FalcoDriverLoader runner with the given test options, and produces
+// an output representing the outcome of the run.
+func Test(runner run.Runner, options ...TestOption) *TestOutput {
+	res := &TestOutput{
+		opts: &testOptions{
+			workdir:  runner.WorkDir(),
+			duration: DefaultMaxDuration,
+		},
+	}
+	for _, o := range options {
+		o(res.opts)
+	}
+	if res.opts.err != nil {
+		return res
+	}
+
+	logrus.WithField("deadline", res.opts.duration).Info("running falco-driver-loader with runner")
+	ctx, cancel := context.WithTimeout(context.Background(), skewedDuration(res.opts.duration))
+	defer cancel()
+	res.err = runner.Run(ctx,
+		run.WithArgs(res.opts.args...),
+		run.WithFiles(res.opts.files...),
+		run.WithStdout(&res.stdout),
+		run.WithStderr(&res.stderr),
+	)
+	if res.err != nil {
+		logrus.WithError(res.err).Warn("error running falco-driver-loader with runner")
+	}
+	return res
+}
+
+func skewedDuration(d time.Duration) time.Duration {
+	return time.Duration(float64(d) * 1.10)
+}

--- a/pkg/falcodriverloader/tester_options.go
+++ b/pkg/falcodriverloader/tester_options.go
@@ -1,0 +1,23 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+package falcodriverloader
+
+// WithArgs runs falco-driver-loader with the given arguments.
+func WithArgs(args ...string) TestOption {
+	return func(ro *testOptions) { ro.args = append(ro.args, args...) }
+}

--- a/pkg/falcodriverloader/tester_output.go
+++ b/pkg/falcodriverloader/tester_output.go
@@ -1,0 +1,61 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+package falcodriverloader
+
+import (
+	"context"
+
+	"github.com/falcosecurity/testing/pkg/run"
+	"go.uber.org/multierr"
+)
+
+// Err returns a non-nil error in case of issues when running falco-driver-loader.
+func (t *TestOutput) Err() error {
+	return multierr.Append(t.opts.err, t.err)
+}
+
+// DurationExceeded returns true if the falco-driver-loader run exceeded the expected
+// duration or if the context had expired.
+func (t *TestOutput) DurationExceeded() bool {
+	for _, err := range multierr.Errors(t.Err()) {
+		if err == context.DeadlineExceeded {
+			return true
+		}
+	}
+	return false
+}
+
+// ExitCode returns the numeric exit code of the falco-driver-loader process.
+func (t *TestOutput) ExitCode() int {
+	for _, err := range multierr.Errors(t.Err()) {
+		if exitCodeErr, ok := err.(*run.ExitCodeError); ok {
+			return exitCodeErr.Code
+		}
+	}
+	return 0
+}
+
+// Stdout returns a string containing the stdout output of the falco-driver-loader run.
+func (t *TestOutput) Stdout() string {
+	return t.stdout.String()
+}
+
+// Stderr returns a string containing the stderr output of the falco-driver-loader run.
+func (t *TestOutput) Stderr() string {
+	return t.stderr.String()
+}

--- a/tests/falco/legacy_test.go
+++ b/tests/falco/legacy_test.go
@@ -2670,7 +2670,7 @@ func TestFalco_Legacy_KubeDemo(t *testing.T) {
 	checkDefaultConfig(t)
 	res := falco.Test(
 		tests.NewFalcoExecutableRunner(t),
-		falco.WithMaxDuration(90*time.Second),
+		falco.WithStopAfter(90*time.Second),
 		falco.WithOutputJSON(),
 		falco.WithCaptureFile(captures.TracesNegativeKubeDemo),
 		falco.WithArgs("-o", "json_include_output_property=false"),
@@ -2988,7 +2988,7 @@ func TestFalco_Legacy_GrpcUnixSocketOutputs(t *testing.T) {
 			falco.WithRules(rules.SingleRuleWithTags),
 			falco.WithConfig(configs.GrpcUnixSocket),
 			falco.WithCaptureFile(captures.CatWrite),
-			falco.WithMaxDuration(30*time.Second),
+			falco.WithStopAfter(30*time.Second),
 			falco.WithArgs("-o", "time_format_iso_8601=true"),
 			falco.WithArgs("-o", "grpc.bind_address=unix://"+socketName),
 		)

--- a/tests/falcodriverloader/drivers_test.go
+++ b/tests/falcodriverloader/drivers_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either exploaderRess or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+package testfalcodriverloader
+
+import (
+	"testing"
+	"time"
+
+	"github.com/falcosecurity/testing/pkg/falco"
+	"github.com/falcosecurity/testing/pkg/falcodriverloader"
+	"github.com/falcosecurity/testing/tests"
+	"github.com/stretchr/testify/assert"
+)
+
+// To run this test you need:
+//   - the driver source code here: `/usr/src/${DRIVER_NAME}-${DRIVER_VERSION}`
+//     (e.g. '/usr/src/falco-942a2249b7b9f65def0a01acfb1fba84f629b3bf')
+//     So before running this test you need to move the folder that you find in the tar.gz under `/usr/src/`
+//   - to be root
+//   - a clang version compatible with your kernel to compile the bpf probe
+//
+// The output probe will be crafted here: `${HOME}/.falco/${DRIVER_VERSION}/${ARCH}/${BPF_PROBE_FILENAME}`
+// (e.g '/root/.falco/942a2249b7b9f65def0a01acfb1fba84f629b3bf/x86_64/falco_ubuntu-generic_6.2.0-26-generic_26~22.04.1.o')
+//
+// We need to use the `--compile` flag because we test against dev versions
+func TestFalcoLegacyBPF(t *testing.T) {
+	loaderRes := falcodriverloader.Test(
+		tests.NewFalcoDriverLoaderExecutableRunner(t),
+		falcodriverloader.WithArgs("bpf", "--compile"),
+	)
+	assert.NoError(t, loaderRes.Err(), "%s", loaderRes.Stderr())
+	assert.Equal(t, 0, loaderRes.ExitCode())
+	// We expect the probe to be symlinked in '/root/.falco/falco-bpf.o'
+	assert.Regexp(t, `Success: eBPF probe symlinked`, loaderRes.Stdout())
+
+	// Now running Falco with `FALCO_BPF_PROBE=/root/.falco/falco-bpf.o` we should be able to run the bpf driver
+	falcoRes := falco.Test(
+		tests.NewFalcoExecutableRunner(t),
+		falco.WithStopAfter(3*time.Second),
+		falco.WithEnvVars(map[string]string{"FALCO_BPF_PROBE": "/root/.falco/falco-bpf.o"}),
+	)
+	assert.NoError(t, falcoRes.Err(), "%s", falcoRes.Stderr())
+	assert.Equal(t, 0, falcoRes.ExitCode())
+	// We want to be sure to run the BPF probe.
+	assert.Regexp(t, `source with BPF probe`, falcoRes.Stderr())
+	// We want to be sure that the engine is correctly opened.
+	assert.Regexp(t, `Events detected:`, falcoRes.Stdout())
+}
+
+// To run this test you need:
+//   - the driver source code here: `/usr/src/${DRIVER_NAME}-${DRIVER_VERSION}`
+//     (e.g. '/usr/src/falco-942a2249b7b9f65def0a01acfb1fba84f629b3bf')
+//     So before running this test you need to move the folder that you find in the tar.gz under `/usr/src/`
+//   - to be root
+//   - a gcc version compatible with your kernel to compile the kernel module
+//
+// The module will be loaded in DKMS:
+// (e.g '/var/lib/dkms/falco/942a2249b7b9f65def0a01acfb1fba84f629b3bf/6.2.0-26-generic/x86_64/module/falco.ko')
+//
+// We need to use the `--compile` flag because we test against dev versions
+func TestFalcoKmod(t *testing.T) {
+	loaderRes := falcodriverloader.Test(
+		tests.NewFalcoDriverLoaderExecutableRunner(t),
+		falcodriverloader.WithArgs("module", "--compile"),
+	)
+	assert.NoError(t, loaderRes.Err(), "%s", loaderRes.Stderr())
+	assert.Equal(t, 0, loaderRes.ExitCode())
+	// We expect the module to be loaded in dkms
+	assert.Regexp(t, `Success: falco module found and loaded in dkms`, loaderRes.Stdout())
+
+	// Now running Falco we should be able to run the kernel module
+	falcoRes := falco.Test(
+		tests.NewFalcoExecutableRunner(t),
+		falco.WithStopAfter(3*time.Second),
+	)
+	assert.NoError(t, falcoRes.Err(), "%s", falcoRes.Stderr())
+	assert.Equal(t, 0, falcoRes.ExitCode())
+	// We want to be sure to run the Kernel module.
+	assert.Regexp(t, `source with Kernel module`, falcoRes.Stderr())
+	// We want to be sure that the engine is correctly opened.
+	assert.Regexp(t, `Events detected:`, falcoRes.Stdout())
+}
+
+// This test doesn't need the falco-driver-loader but we put it here
+// together with the other engines.
+func TestFalcoModernBpf(t *testing.T) {
+	// Now running Falco we should be able to run the kernel module
+	falcoRes := falco.Test(
+		tests.NewFalcoExecutableRunner(t),
+		falco.WithStopAfter(3*time.Second),
+		falco.WithArgs("--modern-bpf"),
+	)
+	assert.NoError(t, falcoRes.Err(), "%s", falcoRes.Stderr())
+	assert.Equal(t, 0, falcoRes.ExitCode())
+	// We want to be sure to run the Kernel module.
+	assert.Regexp(t, `source with modern BPF probe`, falcoRes.Stderr())
+	// We want to be sure that the engine is correctly opened.
+	assert.Regexp(t, `Events detected:`, falcoRes.Stdout())
+}

--- a/tests/falcodriverloader/generate.go
+++ b/tests/falcodriverloader/generate.go
@@ -1,0 +1,20 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+package testfalcodriverloader
+
+//go:generate go test ./... -c -o ../../build/falco-driver-loader.test

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/falcosecurity/testing/pkg/falco"
 	"github.com/falcosecurity/testing/pkg/falcoctl"
+	"github.com/falcosecurity/testing/pkg/falcodriverloader"
 	"github.com/falcosecurity/testing/pkg/run"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -33,11 +34,14 @@ import (
 var falcoStatic = false
 var falcoBinary = falco.DefaultExecutable
 var falcoctlBinary = falcoctl.DefaultLocalExecutable
+var falcoDriverLoaderBinary = falcodriverloader.DefaultExecutable
 
 func init() {
 	flag.BoolVar(&falcoStatic, "falco-static", falcoStatic, "True if the Falco executable is from a static build")
 	flag.StringVar(&falcoBinary, "falco-binary", falcoBinary, "Falco executable binary path")
 	flag.StringVar(&falcoctlBinary, "falcoctl-binary", falcoctlBinary, "falcoctl executable binary path")
+	flag.StringVar(&falcoDriverLoaderBinary, "falco-driver-loader-binary", falcoDriverLoaderBinary, "falco-driver-loader executable binary path")
+
 	logrus.SetLevel(logrus.DebugLevel)
 	logrus.SetFormatter(&logrus.JSONFormatter{})
 }
@@ -45,6 +49,13 @@ func init() {
 // NewFalcoExecutableRunner returns an executable runner for Falco.
 func NewFalcoExecutableRunner(t *testing.T) run.Runner {
 	runner, err := run.NewExecutableRunner(falcoBinary)
+	require.Nil(t, err)
+	return runner
+}
+
+// NewFalcoExecutableRunner returns an executable runner for falco-driver-loader.
+func NewFalcoDriverLoaderExecutableRunner(t *testing.T) run.Runner {
+	runner, err := run.NewExecutableRunner(falcoDriverLoaderBinary)
 	require.Nil(t, err)
 	return runner
 }


### PR DESCRIPTION
This PR adds some e2e tests for the falco driver loader.

We just need to update the falco CI job in the following way:

```bash
 sudo ./build/falco-driver-loader.test
```

Moreover we need to add the toolchain to the test job, so clang, gcc, dkms