### PR TITLE
fix(tests): fixed for falco RCs releases.

### DIFF
--- a/tests/falco/commands_test.go
+++ b/tests/falco/commands_test.go
@@ -54,8 +54,8 @@ func TestFalco_Cmd_Version(t *testing.T) {
 		assert.NoError(t, res.Err(), "%s", res.Stderr())
 		assert.Equal(t, res.ExitCode(), 0)
 		assert.Regexp(t, regexp.MustCompile(
-			`Falco version:[\s]+[0-9]+\.[0-9]+\.[0-9](\-[a-z0-9]+)?(\+[a-f0-9]+)?[\s]+`+
-				`Libs version:[\s]+(([0-9]+\.[0-9]+\.[0-9](\-[a-z0-9]+)?)|([a-f0-9]+))[\s]+`+
+			`Falco version:[\s]+(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?[\s]+`+
+				`Libs version:[\s]+(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?[\s]+`+
 				`Plugin API:[\s]+[0-9]+\.[0-9]+\.[0-9][\s]+`+
 				`Engine:[\s]+[0-9]+[\s]+`+ // note: since falco 0.34.0
 				`Driver:[\s]+`+

--- a/tests/falco/commands_test.go
+++ b/tests/falco/commands_test.go
@@ -54,7 +54,7 @@ func TestFalco_Cmd_Version(t *testing.T) {
 		assert.NoError(t, res.Err(), "%s", res.Stderr())
 		assert.Equal(t, res.ExitCode(), 0)
 		assert.Regexp(t, regexp.MustCompile(
-			`Falco version:[\s]+[0-9]+\.[0-9]+\.[0-9](\-[0-9]+\+[a-f0-9]+)?[\s]+`+
+			`Falco version:[\s]+[0-9]+\.[0-9]+\.[0-9](\-[a-z0-9]+)?(\+[a-f0-9]+)?[\s]+`+
 				`Libs version:[\s]+(([0-9]+\.[0-9]+\.[0-9](\-[a-z0-9]+)?)|([a-f0-9]+))[\s]+`+
 				`Plugin API:[\s]+[0-9]+\.[0-9]+\.[0-9][\s]+`+
 				`Engine:[\s]+[0-9]+[\s]+`+ // note: since falco 0.34.0


### PR DESCRIPTION
Old regex wouldn't match RC Falco releases, like: 0.36.0-rc1; see https://github.com/falcosecurity/falco/actions/runs/6146946513

New regex correctly matches by expecting either:
* none (ie: 0.36.0)
* `-$word`  like: 0.36.0-rc1
* `+$hash` like: 0.36.0+aaaaa
* development versions like: 0.36.0-198+30aa28f

See https://regex101.com/r/Cxg7oX/1