### PR TITLE
fix(artifact): do not run artifact installs in parallel

### DIFF
--- a/tests/falcoctl/artifact_test.go
+++ b/tests/falcoctl/artifact_test.go
@@ -64,7 +64,6 @@ func TestFalcoctl_Artifact_InstallPlugin(t *testing.T) {
 	})
 
 	t.Run("install-plugin", func(t *testing.T) {
-		t.Parallel()
 		require.Nil(t, run.WorkDir(func(sharedWorkDir string) {
 			res := falcoctl.Test(
 				tests.NewFalcoctlExecutableRunner(t),
@@ -82,7 +81,6 @@ func TestFalcoctl_Artifact_InstallPlugin(t *testing.T) {
 	})
 
 	t.Run("install-rules-with-deps", func(t *testing.T) {
-		t.Parallel()
 		require.Nil(t, run.WorkDir(func(sharedWorkDir string) {
 			res := falcoctl.Test(
 				tests.NewFalcoctlExecutableRunner(t),
@@ -103,7 +101,6 @@ func TestFalcoctl_Artifact_InstallPlugin(t *testing.T) {
 	})
 
 	t.Run("install-for-falco", func(t *testing.T) {
-		t.Parallel()
 		require.Nil(t, run.WorkDir(func(sharedWorkDir string) {
 			res := falcoctl.Test(
 				tests.NewFalcoctlExecutableRunner(t),


### PR DESCRIPTION
I believe we are hitting this race condition: https://github.com/sigstore/cosign/issues/2576

Meaning that if we disable parallel runs for those jobs this may get better. I'm not sure if the `t.Parallel()` above those functions should be removed as well.