### PR TITLE
fix(tests/falco): solve issues with description tests for static builds

### DIFF
--- a/tests/falco/commands_test.go
+++ b/tests/falco/commands_test.go
@@ -212,6 +212,7 @@ func TestFalco_Print_Rules(t *testing.T) {
 
 	t.Run("json-valid-rules", func(t *testing.T) {
 		t.Parallel()
+		checkNotStaticExecutable(t)
 		res := falco.Test(
 			runner,
 			falco.WithArgs("-L"),
@@ -220,6 +221,7 @@ func TestFalco_Print_Rules(t *testing.T) {
 			falco.WithRules(rules.RulesDir000SingleRule, rules.RulesListWithPluginJSON),
 		)
 
+		assert.NoError(t, res.Err())
 		infos := res.RulesetDescription()
 		assert.NotNil(t, infos)
 


### PR DESCRIPTION
In the `TestFalco_Print_Rules/json-valid-rules` we load the `json` plugin, which we can't do in  static Falco builds. This is causing failures in bumping the submodule in mainline Falco.