### PR TITLE
fix(tests/falco): invalid rule names must return error when described

### DIFF
--- a/tests/falco/commands_test.go
+++ b/tests/falco/commands_test.go
@@ -331,10 +331,6 @@ func TestFlaco_Rule_Info(t *testing.T) {
 			falco.WithArgs("-l"),
 			falco.WithArgs("invalid"),
 		)
-		assert.NoError(t, res.Err(), "%s", res.Stderr())
-		assert.Regexp(t,
-			`.*Rule[\s]+Description[\s]+`+
-				`[\-]+[\s]+[\-]+[\s]+`,
-			res.Stdout())
+		assert.Error(t, res.Err(), "%s", res.Stderr())
 	})
 }


### PR DESCRIPTION
This change unblocks https://github.com/falcosecurity/falco/pull/2934. That PR makes the behavior of the description feature consistent in case of invalid rule by always returning an error. Before, we used to return an error with JSON output and an empty output with text output.