### PR TITLE
cleanup(falco): remove some legacy tests

### DIFF
--- a/tests/data/rules/falco.go
+++ b/tests/data/rules/falco.go
@@ -352,13 +352,6 @@ var InvalidAppendMacro = run.NewStringFileAccessor(
 `,
 )
 
-var InvalidAppendMacroDangling = run.NewStringFileAccessor(
-	"invalid_append_macro_dangling.yaml",
-	`- macro: dangling append
-  condition: and evt.type=execve
-  append: true`,
-)
-
 var InvalidAppendMacroMultipleDocs = run.NewStringFileAccessor(
 	"invalid_append_macro_multiple_docs.yaml",
 	`---
@@ -644,15 +637,6 @@ var ListAppend = run.NewStringFileAccessor(
   condition: evt.type=open and proc.name in (my_list)
   output: "An open was seen (command=%proc.cmdline)"
   priority: WARNING
-`,
-)
-
-var ListAppendFailure = run.NewStringFileAccessor(
-	"list_append_failure.yaml",
-	`
-- list: my_list
-  items: [not-cat]
-  append: true
 `,
 )
 
@@ -984,15 +968,6 @@ var RuleAppend = run.NewStringFileAccessor(
 - rule: my_rule
   append: true
   condition: or (evt.type=open and fd.name=/dev/null)
-`,
-)
-
-var RuleAppendFailure = run.NewStringFileAccessor(
-	"rule_append_failure.yaml",
-	`
-- rule: my_rule
-  condition: evt.type=open
-  append: true
 `,
 )
 

--- a/tests/falco/legacy_test.go
+++ b/tests/falco/legacy_test.go
@@ -521,23 +521,6 @@ func TestFalco_Legacy_ListSubBare(t *testing.T) {
 	assert.Equal(t, 0, res.ExitCode())
 }
 
-func TestFalco_Legacy_InvalidAppendMacroDangling(t *testing.T) {
-	t.Parallel()
-	checkDefaultConfig(t)
-	res := falco.Test(
-		tests.NewFalcoExecutableRunner(t),
-		falco.WithOutputJSON(),
-		falco.WithRulesValidation(rules.InvalidAppendMacroDangling),
-	)
-	assert.NotNil(t, res.RuleValidation().AllErrors().
-		OfCode("LOAD_ERR_VALIDATE").
-		OfItemType("macro").
-		OfItemName("dangling append").
-		OfMessage("Macro has 'append' key but no macro by that name already exists"))
-	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
-}
-
 func TestFalco_Legacy_InvalidOverwriteMacroMultipleDocs(t *testing.T) {
 	t.Parallel()
 	checkDefaultConfig(t)
@@ -1094,23 +1077,6 @@ func TestFalco_Legacy_MonitorSyscallDropsLog(t *testing.T) {
 	assert.NotRegexp(t, `Falco internal: syscall event drop`, res.Stdout())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
 	assert.Equal(t, 0, res.ExitCode())
-}
-
-func TestFalco_Legacy_InvalidRuleAppendDangling(t *testing.T) {
-	t.Parallel()
-	checkDefaultConfig(t)
-	res := falco.Test(
-		tests.NewFalcoExecutableRunner(t),
-		falco.WithOutputJSON(),
-		falco.WithRulesValidation(rules.RuleAppendFailure),
-	)
-	assert.NotNil(t, res.RuleValidation().AllErrors().
-		OfCode("LOAD_ERR_VALIDATE").
-		OfItemType("rule").
-		OfItemName("my_rule").
-		OfMessage("Rule has 'append' key but no rule by that name already exists"))
-	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
 }
 
 func TestFalco_Legacy_InvalidOverwriteRule(t *testing.T) {
@@ -1709,23 +1675,6 @@ func TestFalco_Legacy_InvalidArrayItemNotObject(t *testing.T) {
 		OfCode("LOAD_ERR_YAML_VALIDATE").
 		OfItemType("rules content item").
 		OfMessage("Unexpected element type. Each element should be a yaml associative array."))
-	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
-}
-
-func TestFalco_Legacy_InvalidListAppendDangling(t *testing.T) {
-	t.Parallel()
-	checkDefaultConfig(t)
-	res := falco.Test(
-		tests.NewFalcoExecutableRunner(t),
-		falco.WithOutputJSON(),
-		falco.WithRulesValidation(rules.ListAppendFailure),
-	)
-	assert.NotNil(t, res.RuleValidation().AllErrors().
-		OfCode("LOAD_ERR_VALIDATE").
-		OfItemType("list").
-		OfItemName("my_list").
-		OfMessage("List has 'append' key but no list by that name already exists"))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
 	assert.Equal(t, 1, res.ExitCode())
 }


### PR DESCRIPTION
remove some legacy tests because now they are supported inside Falco unit tests, see https://github.com/falcosecurity/falco/pull/2992