### PR TITLE
chore(action.yml): use unique name for uploaded artifact.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -109,5 +109,5 @@ runs:
       if: always() # note: upload the report even if tests fail
       uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       with:
-        name: falcosecurity-testing-report
+        name: falcosecurity-testing-report-${{ runner.arch }}
         path: ${{ steps.run-tests.outputs.report }}


### PR DESCRIPTION
Fixup to #46 

cc @LucaGuerra 
See https://github.com/falcosecurity/falco/actions/runs/8662853602/job/23756618239?pr=3154