### PR TITLE
fix(tests): fixed k8saudit list names after recent breaking change.

### DIFF
--- a/tests/data/rules/k8saudit.go
+++ b/tests/data/rules/k8saudit.go
@@ -508,15 +508,15 @@ var K8SAuditSingleRuleWithJsonPointer = run.NewStringFileAccessor(
 
 var K8SAuditTrustNginxContainer = run.NewStringFileAccessor(
 	"trust_nginx_container.yaml",
-	`- list: falco_sensitive_mount_images
+	`- list: k8s_audit_sensitive_mount_images
   items: [nginx]
   append: true
 
-- list: falco_privileged_images
+- list: k8s_audit_privileged_images
   items: [nginx]
   append: true
 
-- list: falco_hostnetwork_images
+- list: k8s_audit_hostnetwork_images
   items: [nginx]
   append: true
 `,


### PR DESCRIPTION
Latest k8saudit plugin (0.8.0) comes with some breaking changes: https://github.com/falcosecurity/plugins/commit/24e9f229e04da96f64eaefff61d221a420062c4f
Adapt the test.