### PR TITLE
new(tests,pkg,action): added 2 new tests around prometheus metrics.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,5 +45,6 @@ jobs:
           test-falco: 'true'
           test-falcoctl: 'true'
           test-k8saudit: 'true'
+          test-dummy: 'true'
           show-all: 'true'
           sudo: ''

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: 'Whether to run k8saudit tests. Default disabled.'
     required: false
     default: 'false'
+  test-dummy:
+    description: 'Whether to run dummy plugin tests. Default disabled.'
+    required: false
+    default: 'false'
   test-drivers:  
     description: 'Whether to run drivers tests. Requires kernel headers to be installed. Default disabled.'
     required: false
@@ -93,6 +97,9 @@ runs:
           fi
           if ${{ inputs.test-k8saudit == 'true' }}; then
             ./build/k8saudit.test -test.timeout=180s -test.v >> ./report.txt 2>&1 || true
+          fi
+          if ${{ inputs.test-dummy == 'true' }}; then
+            ./build/dummy.test -test.timeout=180s -test.v >> ./report.txt 2>&1 || true
           fi
           if ${{ inputs.test-drivers == 'true' }}; then
             ${{ inputs.sudo }} ./build/falco-driver-loader.test -test.timeout=180s -test.v >> ./report.txt 2>&1 || true

--- a/action.yml
+++ b/action.yml
@@ -68,6 +68,7 @@ runs:
         ${{ inputs.sudo }} mkdir -p /usr/share/falco/plugins
         ${{ inputs.sudo }} falcoctl artifact install k8saudit-rules
         ${{ inputs.sudo }} falcoctl artifact install cloudtrail-rules
+        ${{ inputs.sudo }} falcoctl artifact install dummy
    
     - name: Install dependencies for falco-driver-loader tests
       if: ${{ inputs.test-drivers == 'true' }}

--- a/pkg/falco/tester_options.go
+++ b/pkg/falco/tester_options.go
@@ -84,6 +84,17 @@ func WithDisabledSources(sources ...string) TestOption {
 	return withMultipleArgValues("--disable-source", sources...)
 }
 
+// WithPrometheusMetrics runs Falco enabling prometheus metrics endpoint.
+func WithPrometheusMetrics() TestOption {
+	return func(o *testOptions) {
+		o.args = append(o.args, "-o", "metrics.enabled=true")
+		o.args = append(o.args, "-o", "metrics.output_rule=true")
+		o.args = append(o.args, "-o", "metrics.interval=2s")
+		o.args = append(o.args, "-o", "webserver.enabled=true")
+		o.args = append(o.args, "-o", "webserver.prometheus_metrics_enabled=true")
+	}
+}
+
 // WithMinRulePriority runs Falco by forcing a mimimum rules priority.
 func WithMinRulePriority(priority string) TestOption {
 	return func(o *testOptions) {

--- a/tests/dummy/dummy_test.go
+++ b/tests/dummy/dummy_test.go
@@ -1,0 +1,62 @@
+package testdummy
+
+import (
+	"github.com/falcosecurity/testing/pkg/falco"
+	"github.com/falcosecurity/testing/pkg/run"
+	"github.com/falcosecurity/testing/tests"
+	"github.com/falcosecurity/testing/tests/data/plugins"
+	"github.com/falcosecurity/testing/tests/data/rules"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+)
+
+func runFalcoWithDummy(t *testing.T, r run.Runner, opts ...falco.TestOption) *falco.TestOutput {
+	config, err := falco.NewPluginConfig(
+		"plugin-config.yaml",
+		&falco.PluginConfigInfo{
+			Name:       "dummy",
+			Library:    plugins.DummyPlugin.Name(),
+			OpenParams: `'{"start": 1, "maxEvents": 2000000000}'`,
+		},
+	)
+	require.Nil(t, err)
+	options := []falco.TestOption{
+		falco.WithEnabledSources("dummy"),
+		falco.WithConfig(config),
+		falco.WithExtraFiles(plugins.DummyPlugin),
+	}
+	options = append(options, opts...)
+	return falco.Test(r, options...)
+}
+
+func TestDummy_PrometheusMetrics(t *testing.T) {
+	var (
+		wg         sync.WaitGroup
+		metricsErr error
+	)
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		time.Sleep(2 * time.Second)
+		_, metricsErr = http.Get("http://127.0.0.1:8765/metrics")
+	}()
+
+	falcoRes := runFalcoWithDummy(t,
+		tests.NewFalcoExecutableRunner(t),
+		falco.WithPrometheusMetrics(),
+		falco.WithRules(rules.SingleRule),
+		falco.WithStopAfter(5*time.Second),
+		falco.WithArgs("-o", "engine.kind=nodriver"),
+	)
+	assert.NoError(t, falcoRes.Err(), "%s", falcoRes.Stderr())
+	assert.Equal(t, 0, falcoRes.ExitCode())
+
+	wg.Wait()
+
+	assert.NoError(t, metricsErr)
+}

--- a/tests/dummy/generate.go
+++ b/tests/dummy/generate.go
@@ -16,22 +16,6 @@ limitations under the License.
 
 */
 
-package plugins
+package testdummy
 
-import "github.com/falcosecurity/testing/pkg/run"
-
-var K8SAuditPlugin = run.NewLocalFileAccessor(
-	"libk8saudit.so",
-	"/usr/share/falco/plugins/libk8saudit.so")
-
-var CloudtrailPlugin = run.NewLocalFileAccessor(
-	"libcloudtrail.so",
-	"/usr/share/falco/plugins/libcloudtrail.so")
-
-var JSONPlugin = run.NewLocalFileAccessor(
-	"libjson.so",
-	"/usr/share/falco/plugins/libjson.so")
-
-var DummyPlugin = run.NewLocalFileAccessor(
-	"libdummy.so",
-	"/usr/share/falco/plugins/libdummy.so")
+//go:generate go test ./... -c -o ../../build/dummy.test


### PR DESCRIPTION
We have a new dep on the `dummy` plugin (that gets automatically installed by composite action), because we use it to test that prometheus metrics are not killing Falco (-> https://github.com/falcosecurity/falco/issues/3229).

We have also a new test (`TestFalco_Miscs_PrometheusMetricsNoDriver`) to test prometheus metrics in normal Falco run (in nodriver mode).

/cc @jasondellaluce @leogr 