### PR TITLE
fix: update test with latest libs fix

### DIFF
--- a/tests/falco/legacy_test.go
+++ b/tests/falco/legacy_test.go
@@ -2628,7 +2628,7 @@ func TestFalco_Legacy_NonSudoSetuid(t *testing.T) {
 		falco.WithArgs("-o", "json_include_output_property=false"),
 		falco.WithArgs("-o", "json_include_tags_property=false"),
 	)
-	assert.Zero(t, res.Detections().Count())
+	assert.Equal(t, 1, res.Detections().OfRule("Non sudo setuid").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
 	assert.Equal(t, 0, res.ExitCode())
 }


### PR DESCRIPTION
Test `TestFalco_Legacy_NonSudoSetuid` was affected by the bug reported here  https://github.com/falcosecurity/libs/pull/1923. A thread with vtid=-1 was considered as a container thread and for this reason, we didn't match the rule because of this condition `container and not user.name in ("<NA>","N/A","")`. The user is NA and before the fix, we were considered in a container.

Now with the fix, we are no longer in a container so the rule correctly triggers. Full rule output with addition of `thread.vtid` and `thread.tid`

```
22:23:30.177328055: Notice Unexpected setuid call by non-sudo, non-root program (user=<NA> tid=10397, vtid=<NA> user_loginuid=-1 cur_uid=4294967295 parent=<NA> command=<NA> pid=-1 uid=root container_id= image=<NA>)
```