### PR TITLE
fix(tests/legacy): relax json string requirement

### DIFF
--- a/tests/falco/legacy_test.go
+++ b/tests/falco/legacy_test.go
@@ -41,6 +41,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -159,10 +160,16 @@ func TestFalco_Legacy_StdoutOutputJsonStrict(t *testing.T) {
 	assert.Nil(t, err)
 	scanner := bufio.NewScanner(bytes.NewReader(expectedContent))
 	scanner.Split(bufio.ScanLines)
+	var expectedJsonLines []string
 	for scanner.Scan() {
-		assert.Contains(t, res.Stdout(), scanner.Text())
+		expectedJsonLines = append(expectedJsonLines, scanner.Text())
 	}
 	assert.Nil(t, scanner.Err())
+
+	outputLines := strings.Split(res.Stdout(), "\n")
+	for i, expectedLine := range expectedJsonLines {
+		require.JSONEq(t, expectedLine, outputLines[i])
+	}
 }
 
 func TestFalco_Legacy_ListAppendFalse(t *testing.T) {


### PR DESCRIPTION
The `TestFalco_Legacy_StdoutOutputJsonStrict` was checking if the output contained specific json strings that needed to match character by character. This PR changes it so that it requires only that the json object are equivalent even if the strings are different (e.g. same properties printed in different order)