### PR TITLE
cleanup(tests/falco): remove dropped CLI options test.

### DIFF
--- a/pkg/falco/tester_options.go
+++ b/pkg/falco/tester_options.go
@@ -61,17 +61,30 @@ func WithConfig(f run.FileAccessor) TestOption {
 
 // WithEnabledTags runs Falco with enabled rules tags through the `-t` option.
 func WithEnabledTags(tags ...string) TestOption {
-	return withMultipleArgValues("-t", tags...)
+	return func(o *testOptions) {
+		o.args = append(o.args, "-o", "rules[].disable.rule=*")
+		for _, t := range tags {
+			o.args = append(o.args, "-o", "rules[].enable.tag="+t)
+		}
+	}
 }
 
 // WithDisabledTags runs Falco with disabled rules tags through the `-T` option.
 func WithDisabledTags(tags ...string) TestOption {
-	return withMultipleArgValues("-T", tags...)
+	return func(o *testOptions) {
+		for _, t := range tags {
+			o.args = append(o.args, "-o", "rules[].disable.tag="+t)
+		}
+	}
 }
 
-// WithDisabledRules runs Falco with disabled rules through the `-D` option.
+// WithDisabledRules runs Falco with disabled rules through the `rules:` config option.
 func WithDisabledRules(rules ...string) TestOption {
-	return withMultipleArgValues("-D", rules...)
+	return func(o *testOptions) {
+		for _, r := range rules {
+			o.args = append(o.args, "-o", "rules[].disable.rule="+r)
+		}
+	}
 }
 
 // WithEnabledSources runs Falco with enabled event sources through the `--enable-source` option.

--- a/tests/falco/legacy_test.go
+++ b/tests/falco/legacy_test.go
@@ -1567,21 +1567,6 @@ func TestFalco_Legacy_InvalidAppendRuleMultipleDocs(t *testing.T) {
 	assert.Equal(t, 1, res.ExitCode())
 }
 
-func TestFalco_Legacy_DisabledAndEnabledRules2(t *testing.T) {
-	t.Parallel()
-	checkConfig(t)
-	res := falco.Test(
-		tests.NewFalcoExecutableRunner(t),
-		falco.WithRules(rules.SingleRule),
-		falco.WithDisabledRules("open.*"),
-		falco.WithEnabledTags("a"),
-		falco.WithCaptureFile(captures.CatWrite),
-	)
-	assert.Regexp(t, `Error: You can not specify both disabled .-D/-T. and enabled .-t. rules`, res.Stderr())
-	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
-}
-
 func TestFalco_Legacy_RunTagsAb(t *testing.T) {
 	t.Parallel()
 	checkConfig(t)

--- a/tests/falco/legacy_test.go
+++ b/tests/falco/legacy_test.go
@@ -105,21 +105,6 @@ func TestFalco_Legacy_Endswith(t *testing.T) {
 	assert.Equal(t, 0, res.ExitCode())
 }
 
-func TestFalco_Legacy_DisabledAndEnabledRules1(t *testing.T) {
-	t.Parallel()
-	checkConfig(t)
-	res := falco.Test(
-		tests.NewFalcoExecutableRunner(t),
-		falco.WithRules(rules.SingleRule),
-		falco.WithDisabledTags("a"),
-		falco.WithEnabledTags("a"),
-		falco.WithCaptureFile(captures.CatWrite),
-	)
-	assert.Regexp(t, `Error: You can not specify both disabled .-D/-T. and enabled .-t. rules`, res.Stderr())
-	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
-}
-
 func TestFalco_Legacy_StdoutOutputStrict(t *testing.T) {
 	t.Parallel()
 	res := falco.Test(


### PR DESCRIPTION
https://github.com/falcosecurity/falco/pull/3311 is dropping the deprecated `-t,-T,-D` options.
This PR removes `TestFalco_Legacy_DisabledAndEnabledRules1` and `TestFalco_Legacy_DisabledAndEnabledRules2` tests since they are no more needed.
Also, it bumps all other tests regarding rule disable/enable tags to the newly introduced in Falco 0.38 `rules:` config key: https://github.com/falcosecurity/falco/pull/3178