### PR TITLE
cleanup(tests): remove wrong/unused assert.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
     name: Run Tests on falcosecurity/falco image
     runs-on: ubuntu-latest
     container:
-      image: falcosecurity/falco:${{ github.event.inputs.version || 'master' }}
+      image: falcosecurity/falco-driver-loader:${{ github.event.inputs.version || 'master' }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/tests/falco/legacy_test.go
+++ b/tests/falco/legacy_test.go
@@ -2665,7 +2665,6 @@ func TestFalco_Legacy_FalcoEventGenerator(t *testing.T) {
 	assert.Equal(t, 1, res.Detections().OfRule("Write below etc").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("System procs network activity").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("Mkdir binary dirs").Count())
-	assert.Equal(t, 1, res.Detections().OfRule("System user interactive").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("DB program spawned process").Count())
 	assert.Equal(t, 0, res.Detections().OfRule("Non sudo setuid").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("Create files below dev").Count())


### PR DESCRIPTION
https://github.com/falcosecurity/libs/pull/2165 exposed a bug in the `TestFalco_Legacy_FalcoEventGenerator` test.
Previous code was storing full user/group info in threadinfo; before parsers understood that container_id was changed (ie: we entered a container), `set_{user,group}` was called (eg here: https://github.com/falcosecurity/libs/blob/master/userspace/libsinsp/parsers.cpp#L1769), storing in the threadinfo user and group information related to uid and gid for the host. Then, when refreshing info for the container(https://github.com/falcosecurity/libs/blob/master/userspace/libsinsp/parsers.cpp#L1843), since the container data cannot be loaded while replaying a scap file, and since the scap file itself does not container `useradded` events (being too old), we did not overwrite existing user/group info stored in the threadinfo.
Therefore the threadinfo was returning user and group releted info mapped to the host while being on a container.

The new code fixed that behavior but then the test fails. Since we have no way to retrieve the correctly mapped-to-the-container user and group info while replaying a scap file that has no `useradded` events, we can only remove the assert.