### PR TITLE
chore(pkg/falco): use `base_syscalls.all` instead of `-A` to enable all syscalls

### DIFF
--- a/pkg/falco/tester_options.go
+++ b/pkg/falco/tester_options.go
@@ -125,7 +125,7 @@ func WithOutputJSON() TestOption {
 // WithAllEvents runs Falco with all events enabled through the `-A` option.
 func WithAllEvents() TestOption {
 	return func(o *testOptions) {
-		o.args = append(o.args, "-A")
+		o.args = append(o.args, "-o", "base_syscalls.all=true")
 	}
 }
 


### PR DESCRIPTION
`-A` is going to be dropped in 0.41.0
/hold