### PR TITLE
Fix plugin config init config template

### DIFF
--- a/pkg/falco/helpers.go
+++ b/pkg/falco/helpers.go
@@ -37,8 +37,7 @@ type PluginConfigInfo struct {
 	InitConfig interface{}
 }
 
-//lint:ignore U1000 this receiver is invoked in a tamplete and is not actually unused
-func (p *PluginConfigInfo) initConfigString() string {
+func (p *PluginConfigInfo) InitConfigString() string {
 	if p.InitConfig == nil {
 		return ""
 	}
@@ -72,7 +71,7 @@ stdout_output:
 plugins:
 {{ range $i, $p := . }}  - name: {{ $p.Name }}
     library_path: {{ $p.Library }}{{ if $p.InitConfig }}
-    init_config: {{ call $p.initConfigString }}{{ end }}{{ if $p.OpenParams }}
+    init_config: {{ $p.InitConfigString }}{{ end }}{{ if $p.OpenParams }}
     open_params: {{ $p.OpenParams }}{{ end }}
 {{ end }}load_plugins:{{ range $i, $p := . }}
   - {{ $p.Name }}

--- a/tests/dummy/dummy_test.go
+++ b/tests/dummy/dummy_test.go
@@ -20,6 +20,7 @@ func runFalcoWithDummy(t *testing.T, r run.Runner, opts ...falco.TestOption) *fa
 		&falco.PluginConfigInfo{
 			Name:       "dummy",
 			Library:    plugins.DummyPlugin.Name(),
+			InitConfig: `{"foo": "bar"}`, // add dummy init config to ensure plugins with init config work
 			OpenParams: `'{"start": 1, "maxEvents": 2000000000}'`,
 		},
 	)


### PR DESCRIPTION
## WHAT
Add dummy InitConfig to dummy test to force init config templating logic to run.
Fix the PluginConfigInfo InitiConfig templating to use exported function and directly call it.

This fix is necessary to for example test Falco rules using this pkg when plugins such as the k8smeta plugin are required as the plugin has a few required init config fields.


## WHY

The go template logic requires the the field to be exported in order to be able to render it. For unexported fields we otherwise see an error like this:
```
template: :7:27: executing "" at <$p.initConfigString>: can't evaluate field initConfigString in type *falco.PluginConfigInfo
```

Similarly it seems that for struct functions evaluating to string the template pkg seems to treat them as fields. So using the `call` keyword results in the below error:
```
template: :7:20: executing "" at <call $p.InitConfigString>: error calling call: non-function $p.InitConfigString of type string
```

Thus fixing this requires exporting the function and removing the `call` keyword. This can be verified by running the `TestDummy_PrometheusMetrics` test while 1e5609610ed7380baec5426b49d99d989c8e9b72 is checked out.