### PR TITLE
fix(tests/falco): adapt to falco `0.42.0`

### DIFF
--- a/tests/data/outputs/outputs.go
+++ b/tests/data/outputs/outputs.go
@@ -22,24 +22,16 @@ import "github.com/falcosecurity/testing/pkg/run"
 
 var SingleRuleWithCatWriteText = run.NewStringFileAccessor(
 	"single_rule_with_cat_write.txt",
-	`2016-08-04T16:17:57.881781397+0000: Warning An open was seen (command=cat /dev/null)
-2016-08-04T16:17:57.881785348+0000: Warning An open was seen (command=cat /dev/null)
-2016-08-04T16:17:57.881796705+0000: Warning An open was seen (command=cat /dev/null)
+	`2016-08-04T16:17:57.881785348+0000: Warning An open was seen (command=cat /dev/null)
 2016-08-04T16:17:57.881799840+0000: Warning An open was seen (command=cat /dev/null)
-2016-08-04T16:17:57.882003104+0000: Warning An open was seen (command=cat /dev/null)
 2016-08-04T16:17:57.882008208+0000: Warning An open was seen (command=cat /dev/null)
-2016-08-04T16:17:57.882045694+0000: Warning An open was seen (command=cat /dev/null)
 2016-08-04T16:17:57.882054739+0000: Warning An open was seen (command=cat /dev/null)
 `)
 
 var SingleRuleWithCatWriteJSON = run.NewStringFileAccessor(
 	"single_rule_with_cat_write.json",
-	`{"hostname":"test-falco-hostname","output":"2016-08-04T16:17:57.881781397+0000: Warning An open was seen (command=cat /dev/null)","priority":"Warning","rule":"open_from_cat","source":"syscall","tags":["filesystem","process","testing"],"time":"2016-08-04T16:17:57.881781397Z", "output_fields": {"evt.time.iso8601":1470327477881781397,"proc.cmdline":"cat /dev/null"}}
-{"hostname":"test-falco-hostname","output":"2016-08-04T16:17:57.881785348+0000: Warning An open was seen (command=cat /dev/null)","priority":"Warning","rule":"open_from_cat","source":"syscall","tags":["filesystem","process","testing"],"time":"2016-08-04T16:17:57.881785348Z", "output_fields": {"evt.time.iso8601":1470327477881785348,"proc.cmdline":"cat /dev/null"}}
-{"hostname":"test-falco-hostname","output":"2016-08-04T16:17:57.881796705+0000: Warning An open was seen (command=cat /dev/null)","priority":"Warning","rule":"open_from_cat","source":"syscall","tags":["filesystem","process","testing"],"time":"2016-08-04T16:17:57.881796705Z", "output_fields": {"evt.time.iso8601":1470327477881796705,"proc.cmdline":"cat /dev/null"}}
+	`{"hostname":"test-falco-hostname","output":"2016-08-04T16:17:57.881785348+0000: Warning An open was seen (command=cat /dev/null)","priority":"Warning","rule":"open_from_cat","source":"syscall","tags":["filesystem","process","testing"],"time":"2016-08-04T16:17:57.881785348Z", "output_fields": {"evt.time.iso8601":1470327477881785348,"proc.cmdline":"cat /dev/null"}}
 {"hostname":"test-falco-hostname","output":"2016-08-04T16:17:57.881799840+0000: Warning An open was seen (command=cat /dev/null)","priority":"Warning","rule":"open_from_cat","source":"syscall","tags":["filesystem","process","testing"],"time":"2016-08-04T16:17:57.881799840Z", "output_fields": {"evt.time.iso8601":1470327477881799840,"proc.cmdline":"cat /dev/null"}}
-{"hostname":"test-falco-hostname","output":"2016-08-04T16:17:57.882003104+0000: Warning An open was seen (command=cat /dev/null)","priority":"Warning","rule":"open_from_cat","source":"syscall","tags":["filesystem","process","testing"],"time":"2016-08-04T16:17:57.882003104Z", "output_fields": {"evt.time.iso8601":1470327477882003104,"proc.cmdline":"cat /dev/null"}}
 {"hostname":"test-falco-hostname","output":"2016-08-04T16:17:57.882008208+0000: Warning An open was seen (command=cat /dev/null)","priority":"Warning","rule":"open_from_cat","source":"syscall","tags":["filesystem","process","testing"],"time":"2016-08-04T16:17:57.882008208Z", "output_fields": {"evt.time.iso8601":1470327477882008208,"proc.cmdline":"cat /dev/null"}}
-{"hostname":"test-falco-hostname","output":"2016-08-04T16:17:57.882045694+0000: Warning An open was seen (command=cat /dev/null)","priority":"Warning","rule":"open_from_cat","source":"syscall","tags":["filesystem","process","testing"],"time":"2016-08-04T16:17:57.882045694Z", "output_fields": {"evt.time.iso8601":1470327477882045694,"proc.cmdline":"cat /dev/null"}}
 {"hostname":"test-falco-hostname","output":"2016-08-04T16:17:57.882054739+0000: Warning An open was seen (command=cat /dev/null)","priority":"Warning","rule":"open_from_cat","source":"syscall","tags":["filesystem","process","testing"],"time":"2016-08-04T16:17:57.882054739Z", "output_fields": {"evt.time.iso8601":1470327477882054739,"proc.cmdline":"cat /dev/null"}}
 `)

--- a/tests/falco/commands_test.go
+++ b/tests/falco/commands_test.go
@@ -302,7 +302,7 @@ func TestFalco_Print_Rules(t *testing.T) {
 	})
 }
 
-func TestFlaco_Rule_Info(t *testing.T) {
+func TestFalco_Rule_Info(t *testing.T) {
 	t.Parallel()
 	runner := tests.NewFalcoExecutableRunner(t)
 	t.Run("valid-rule-name", func(t *testing.T) {

--- a/tests/falco/legacy_test.go
+++ b/tests/falco/legacy_test.go
@@ -264,7 +264,7 @@ func TestFalco_Legacy_DetectSkipUnknownNoevt(t *testing.T) {
 		falco.WithRules(rules.SkipUnknownEvt),
 		falco.WithCaptureFile(captures.CatWrite),
 	)
-	assert.Equal(t, 8, res.Detections().Count())
+	assert.Equal(t, 4, res.Detections().Count())
 	assert.NotZero(t, res.Detections().OfPriority("INFO").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
 	assert.Equal(t, 0, res.ExitCode())
@@ -717,7 +717,7 @@ func TestFalco_Legacy_MultipleRulesSuppressInfo(t *testing.T) {
 	assert.NotZero(t, res.Detections().Count())
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NotZero(t, res.Detections().OfPriority("ERROR").Count())
-	assert.Equal(t, 8, res.Detections().OfRule("open_from_cat").Count())
+	assert.Equal(t, 4, res.Detections().OfRule("open_from_cat").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("exec_from_cat").Count())
 	assert.Equal(t, 0, res.Detections().OfRule("access_from_cat").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
@@ -952,7 +952,7 @@ func TestFalco_Legacy_CatchallOrder(t *testing.T) {
 	assert.NotZero(t, res.Detections().Count())
 	assert.NotZero(t, res.Detections().OfPriority("INFO").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("open_dev_null").Count())
-	assert.Equal(t, 6, res.Detections().OfRule("dev_null").Count())
+	assert.Equal(t, 3, res.Detections().OfRule("dev_null").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
 	assert.Equal(t, 0, res.ExitCode())
 }
@@ -2600,7 +2600,7 @@ func TestFalco_Legacy_NonSudoSetuid(t *testing.T) {
 		falco.WithArgs("-o", "json_include_output_property=false"),
 		falco.WithArgs("-o", "json_include_tags_property=false"),
 	)
-	assert.Equal(t, 1, res.Detections().OfRule("Non sudo setuid").Count())
+	assert.Equal(t, 0, res.Detections().OfRule("Non sudo setuid").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
 	assert.Equal(t, 0, res.ExitCode())
 }
@@ -2707,7 +2707,7 @@ func TestFalco_Legacy_RuleNamesWithRegexChars(t *testing.T) {
 	)
 	assert.NotZero(t, res.Detections().Count())
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
-	assert.Equal(t, 8, res.Detections().OfRule(`Open From Cat ($\.*+?()[]{}|^)`).Count())
+	assert.Equal(t, 4, res.Detections().OfRule(`Open From Cat ($\.*+?()[]{}|^)`).Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
 	assert.Equal(t, 0, res.ExitCode())
 }
@@ -2798,7 +2798,7 @@ func TestFalco_Legacy_EnabledRuleUsingFalseEnabledFlagOnly(t *testing.T) {
 		falco.WithArgs("-o", "json_include_tags_property=false"),
 	)
 	assert.NotZero(t, res.Detections().Count())
-	assert.Equal(t, 8, res.Detections().OfRule("open_from_cat").Count())
+	assert.Equal(t, 4, res.Detections().OfRule("open_from_cat").Count())
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
 	assert.Equal(t, 0, res.ExitCode())


### PR DESCRIPTION
This PR fixes Falco regression tests by adapting their logic for the new Falco 0.42.0 breaking changes.
Notice that errors related to `TestFalco_Legacy_StagingWorker` test are not addressed in this PR.