### PR TITLE
fix: authenticate falcoctl to ghcr

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -72,6 +72,8 @@ runs:
     - name: Install needed artifacts using falcoctl
       if: ${{ inputs.static == 'false' }}
       shell: bash
+      env:
+        FALCOCTL_REGISTRY_AUTH_BASIC: ghcr.io,${{ github.repository_owner }},${{ github.token }}
       run: |
         ${{ inputs.sudo }} mkdir -p /usr/share/falco/plugins
         ${{ inputs.sudo }} falcoctl artifact install k8saudit-rules


### PR DESCRIPTION
Authenticate to GitHub Container Registry to pull falcoctl image. This is a temporary mitigation for the rate limiting issue. See https://github.com/falcosecurity/rules/issues/331