### PR TITLE
chore!: drop legacy BPF probe tests

### DIFF
--- a/tests/falco/miscs_test.go
+++ b/tests/falco/miscs_test.go
@@ -19,14 +19,15 @@ limitations under the License.
 package testfalco
 
 import (
-	"github.com/falcosecurity/testing/pkg/run"
-	"github.com/falcosecurity/testing/tests/data/rules"
 	"net/http"
 	"os"
 	"path/filepath"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/falcosecurity/testing/pkg/run"
+	"github.com/falcosecurity/testing/tests/data/rules"
 
 	"github.com/falcosecurity/testing/pkg/falco"
 	"github.com/falcosecurity/testing/tests"
@@ -43,13 +44,13 @@ import (
 // todo(jasondellaluce): test Falco behavior on environment variables and their
 // priorities in combination with their args/configs/cmds counterparts:
 //   FALCO_K8S_API, FALCO_K8S_API_CERT, FALCO_MESOS_API, FALCO_HOSTNAME,
-//   FALCO_GRPC_HOSTNAME, FALCO_BPF_PROBE, HOME (used for bpf probe)
+//   FALCO_GRPC_HOSTNAME
 //
 // todo(jasondellaluce): implement tests for Falco reaction to signals:
 //   SIGINT, SIGUSR1, SIGHUP
 //
 // todo(jasondellaluce): implement tests for other non-covered Falco things:
-//   - collection of live events with kmod, bpf, modern-bpf, gvisor, userspace
+//   - collection of live events with kmod, modern-bpf, gvisor, userspace
 //   - collection of live events with multiple event sources active at the same
 //   - stress test with event generator, checking memory usage and event drops
 

--- a/tests/falcodriverloader/drivers_test.go
+++ b/tests/falcodriverloader/drivers_test.go
@@ -34,42 +34,6 @@ import (
 //     (e.g. '/usr/src/falco-942a2249b7b9f65def0a01acfb1fba84f629b3bf')
 //     So before running this test you need to move the folder that you find in the tar.gz under `/usr/src/`
 //   - to be root
-//   - a clang version compatible with your kernel to compile the bpf probe
-//
-// The output probe will be crafted here: `${HOME}/.falco/${DRIVER_VERSION}/${ARCH}/${BPF_PROBE_FILENAME}`
-// (e.g '/root/.falco/942a2249b7b9f65def0a01acfb1fba84f629b3bf/x86_64/falco_ubuntu-generic_6.2.0-26-generic_26~22.04.1.o')
-//
-// We need to use the `--download=false` flag because we test against dev versions
-func TestFalcoLegacyBPF(t *testing.T) {
-	loaderRes := falcoctl.Test(
-		tests.NewFalcoctlExecutableRunner(t),
-		falcoctl.WithArgs("driver", "install", "--download=false", "--type", "ebpf"),
-	)
-	assert.NoError(t, loaderRes.Err(), "%s", loaderRes.Stderr())
-	assert.Equal(t, 0, loaderRes.ExitCode())
-	// We expect the probe to be succesfully built and copied to /root/.falco/falco-bpf.o
-	assert.Regexp(t, `eBPF probe available.`, loaderRes.Stdout())
-
-	// Now running Falco with `FALCO_BPF_PROBE=/root/.falco/falco-bpf.o` we should be able to run the bpf driver
-	falcoRes := falco.Test(
-		tests.NewFalcoExecutableRunner(t),
-		falco.WithStopAfter(3*time.Second),
-		falco.WithArgs("-o", "engine.kind=ebpf"),
-		falco.WithArgs("-o", "engine.ebpf.probe=/root/.falco/falco-bpf.o"),
-	)
-	assert.NoError(t, falcoRes.Err(), "%s", falcoRes.Stderr())
-	assert.Equal(t, 0, falcoRes.ExitCode())
-	// We want to be sure to run the BPF probe.
-	assert.Regexp(t, `source with BPF probe`, falcoRes.Stderr())
-	// We want to be sure that the engine is correctly opened.
-	assert.Regexp(t, `Events detected:`, falcoRes.Stdout())
-}
-
-// To run this test you need:
-//   - the driver source code here: `/usr/src/${DRIVER_NAME}-${DRIVER_VERSION}`
-//     (e.g. '/usr/src/falco-942a2249b7b9f65def0a01acfb1fba84f629b3bf')
-//     So before running this test you need to move the folder that you find in the tar.gz under `/usr/src/`
-//   - to be root
 //   - a gcc version compatible with your kernel to compile the kernel module
 //
 // The module will be loaded in DKMS:


### PR DESCRIPTION
Falco 0.43.0 deprecated the legacy eBPF probe, and the support will be removed soon in the next libs release. This PR drops any tests testing it.