### PR TITLE
chore: expose process exit reasons when assertions fail

### DIFF
--- a/pkg/falco/tester_output.go
+++ b/pkg/falco/tester_output.go
@@ -21,6 +21,7 @@ package falco
 import (
 	"context"
 	"encoding/json"
+	"errors"
 
 	"github.com/falcosecurity/testing/pkg/run"
 	"github.com/sirupsen/logrus"
@@ -52,14 +53,25 @@ func (t *TestOutput) DurationExceeded() bool {
 	return false
 }
 
-// ExitCode returns the numeric exit code of the Falco process.
+// ExitCode returns the numeric exit code of the Falco process or -1, in case the process was terminated by a signal.
+// In this latter case, the details can be retrieved leveraging ExitDesc.
 func (t *TestOutput) ExitCode() int {
 	for _, err := range multierr.Errors(t.Err()) {
-		if exitCodeErr, ok := err.(*run.ExitCodeError); ok {
-			return exitCodeErr.Code
+		if exitErr := (*run.ExitError)(nil); errors.As(err, &exitErr) {
+			return exitErr.Code
 		}
 	}
 	return 0
+}
+
+// ExitDesc returns a description of the exit reason of the Falco process.
+func (t *TestOutput) ExitDesc() string {
+	for _, err := range multierr.Errors(t.Err()) {
+		if exitErr := (*run.ExitError)(nil); errors.As(err, &exitErr) {
+			return exitErr.Desc
+		}
+	}
+	return ""
 }
 
 // Stdout returns a string containing the stdout output of the Falco run.

--- a/pkg/falcoctl/tester_output.go
+++ b/pkg/falcoctl/tester_output.go
@@ -20,6 +20,7 @@ package falcoctl
 
 import (
 	"context"
+	"errors"
 
 	"github.com/falcosecurity/testing/pkg/run"
 	"go.uber.org/multierr"
@@ -41,14 +42,25 @@ func (t *TestOutput) DurationExceeded() bool {
 	return false
 }
 
-// ExitCode returns the numeric exit code of the falcoctl process.
+// ExitCode returns the numeric exit code of the falcoctl processor or -1, in case the process was terminated by a
+// signal. In this latter case, the details can be retrieved leveraging ExitDesc.
 func (t *TestOutput) ExitCode() int {
 	for _, err := range multierr.Errors(t.Err()) {
-		if exitCodeErr, ok := err.(*run.ExitCodeError); ok {
-			return exitCodeErr.Code
+		if exitErr := (*run.ExitError)(nil); errors.As(err, &exitErr) {
+			return exitErr.Code
 		}
 	}
 	return 0
+}
+
+// ExitDesc returns a description of the exit reason of the falcoctl process.
+func (t *TestOutput) ExitDesc() string {
+	for _, err := range multierr.Errors(t.Err()) {
+		if exitErr := (*run.ExitError)(nil); errors.As(err, &exitErr) {
+			return exitErr.Desc
+		}
+	}
+	return ""
 }
 
 // Stdout returns a string containing the stdout output of the falcoctl run.

--- a/pkg/run/executable.go
+++ b/pkg/run/executable.go
@@ -20,6 +20,7 @@ package run
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -113,8 +114,8 @@ func (e *execRunner) Run(ctx context.Context, options ...RunnerOption) error {
 	}
 
 	err := cmd.Run()
-	if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() != 0 {
-		err = &ExitCodeError{Code: exitErr.ExitCode()}
+	if exitErr := (*exec.ExitError)(nil); errors.As(err, &exitErr) {
+		err = &ExitError{Code: exitErr.ExitCode(), Desc: exitErr.String()}
 	}
 	return err
 }

--- a/pkg/run/runner.go
+++ b/pkg/run/runner.go
@@ -81,13 +81,15 @@ func WithEnvVars(vars map[string]string) RunnerOption {
 	}
 }
 
-// ExitCodeError is an error representing the exit code of Falco
-type ExitCodeError struct {
+// ExitError is an error representing the exit code of Falco and a description of the exit reason (useful when Falco
+// process crashes).
+type ExitError struct {
 	Code int
+	Desc string
 }
 
-func (c *ExitCodeError) Error() string {
-	return fmt.Sprintf("error code %d", c.Code)
+func (c *ExitError) Error() string {
+	return fmt.Sprintf("exit error(code: %d, desc: %s)", c.Code, c.Desc)
 }
 
 func buildRunOptions(opts ...RunnerOption) *runOpts {

--- a/tests/dummy/dummy_test.go
+++ b/tests/dummy/dummy_test.go
@@ -55,7 +55,7 @@ func TestDummy_PrometheusMetrics(t *testing.T) {
 		falco.WithArgs("-o", "engine.kind=nodriver"),
 	)
 	assert.NoError(t, falcoRes.Err(), "%s", falcoRes.Stderr())
-	assert.Equal(t, 0, falcoRes.ExitCode())
+	assert.Zero(t, falcoRes.ExitCode(), falcoRes.ExitDesc())
 
 	wg.Wait()
 

--- a/tests/falco/commands_test.go
+++ b/tests/falco/commands_test.go
@@ -59,7 +59,7 @@ func TestFalco_Cmd_Version(t *testing.T) {
 		t.Parallel()
 		res := falco.Test(runner, falco.WithArgs("--version"))
 		assert.NoError(t, res.Err(), "%s", res.Stderr())
-		assert.Equal(t, res.ExitCode(), 0)
+		assert.Zero(t, res.ExitCode(), res.ExitDesc())
 		// Falco version supports:
 		// - (dev) -> 0.36.0-198+30aa28f
 		// - (release) -> 0.36.0
@@ -91,7 +91,7 @@ func TestFalco_Cmd_Version(t *testing.T) {
 		)
 		out := res.StdoutJSON()
 		assert.NoError(t, res.Err(), "%s", res.Stderr())
-		assert.Equal(t, res.ExitCode(), 0)
+		assert.Zero(t, res.ExitCode(), res.ExitDesc())
 		assert.Contains(t, out, "default_driver_version")
 		assert.Contains(t, out, "driver_api_version")
 		assert.Contains(t, out, "driver_schema_version")
@@ -112,7 +112,7 @@ func TestFalco_Cmd_ListPlugins(t *testing.T) {
 		falco.WithArgs("-o", "load_plugins[0]=container"),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, res.ExitCode(), 0)
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 	assert.Regexp(t, regexp.MustCompile(
 		`1 Plugins Loaded:[\s]+`+
 			`Name: container[\s]+`+
@@ -136,7 +136,7 @@ func TestFalco_Cmd_PluginInfo(t *testing.T) {
 		falco.WithArgs("-o", "load_plugins[0]=container"),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, res.ExitCode(), 0)
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 	assert.Regexp(t, regexp.MustCompile(
 		`Name: container[\s]+`+
 			`Description: .*[\s]+`+
@@ -168,7 +168,7 @@ func TestFalco_Print_IgnoredEvents(t *testing.T) {
 		assert.Contains(t, res.Stdout(), event)
 	}
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, res.ExitCode(), 0)
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Print_Rules(t *testing.T) {
@@ -185,7 +185,7 @@ func TestFalco_Print_Rules(t *testing.T) {
 			falco.WithRules(rules.InvalidRuleOutput),
 		)
 		assert.Error(t, res.Err(), "%s", res.Stderr())
-		assert.Equal(t, res.ExitCode(), 1)
+		assert.Equal(t, res.ExitCode(), 1, res.ExitDesc())
 	})
 
 	t.Run("text-valid-rules", func(t *testing.T) {
@@ -200,7 +200,7 @@ func TestFalco_Print_Rules(t *testing.T) {
 			assert.Contains(t, res.Stdout(), rule)
 		}
 		assert.NoError(t, res.Err(), "%s", res.Stderr())
-		assert.Equal(t, res.ExitCode(), 0)
+		assert.Zero(t, res.ExitCode(), res.ExitDesc())
 	})
 
 	t.Run("json-valid-rules", func(t *testing.T) {
@@ -375,7 +375,7 @@ func TestFalco_Cmd_Help(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			res := falco.Test(runner, falco.WithArgs(tc.args...))
 			assert.NoError(t, res.Err(), "%s", res.Stderr())
-			assert.Equal(t, res.ExitCode(), 0)
+			assert.Zero(t, res.ExitCode(), res.ExitDesc())
 
 			out := res.Stdout()
 

--- a/tests/falco/config_test.go
+++ b/tests/falco/config_test.go
@@ -39,7 +39,7 @@ func TestFalco_Config_RuleMatchingFirst(t *testing.T) {
 		falco.WithOutputJSON(),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 	assert.Equal(t, 1, res.Detections().Count())
 	assert.Equal(t, 1, res.Detections().OfRule("open_1").Count())
 }
@@ -54,7 +54,7 @@ func TestFalco_Config_RuleMatchingAll(t *testing.T) {
 		falco.WithOutputJSON(),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 	assert.Equal(t, 2, res.Detections().Count())
 	assert.Equal(t, 1, res.Detections().OfRule("open_1").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("open_2").Count())
@@ -72,7 +72,7 @@ func TestFalco_Config_RuleMatchingWrongValue(t *testing.T) {
 	assert.NotNil(t, res.Stderr())
 	assert.Error(t, res.Err(), "%s", res.Stderr())
 	assert.Contains(t, res.Stderr(), "Unknown rule matching strategy")
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Config_Metrics_Enabled(t *testing.T) {
@@ -85,5 +85,5 @@ func TestFalco_Config_Metrics_Enabled(t *testing.T) {
 		falco.WithOutputJSON(),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }

--- a/tests/falco/legacy_test.go
+++ b/tests/falco/legacy_test.go
@@ -67,7 +67,7 @@ func TestFalco_Legacy_EngineVersionMismatch(t *testing.T) {
 	assert.NotNil(t, res.RuleValidation().AllErrors().
 		OfCode("LOAD_ERR_VALIDATE").
 		OfItemType("required_engine_version"))
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_MacroOverriding(t *testing.T) {
@@ -79,7 +79,7 @@ func TestFalco_Legacy_MacroOverriding(t *testing.T) {
 		falco.WithCaptureFile(captures.CatWrite),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_Endswith(t *testing.T) {
@@ -96,7 +96,7 @@ func TestFalco_Legacy_Endswith(t *testing.T) {
 	assert.NotZero(t, res.Detections().Count())
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_StdoutOutputStrict(t *testing.T) {
@@ -109,7 +109,7 @@ func TestFalco_Legacy_StdoutOutputStrict(t *testing.T) {
 		falco.WithArgs("-o", "time_format_iso_8601=true"),
 	)
 
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 	expectedContent, err := outputs.SingleRuleWithCatWriteText.Content()
 	assert.Nil(t, err)
 	scanner := bufio.NewScanner(bytes.NewReader(expectedContent))
@@ -134,7 +134,7 @@ func TestFalco_Legacy_StdoutOutputJsonStrict(t *testing.T) {
 		falco.WithEnvVars(map[string]string{"FALCO_HOSTNAME": "test-falco-hostname"}),
 	)
 
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 	expectedContent, err := outputs.SingleRuleWithCatWriteJSON.Content()
 	assert.Nil(t, err)
 	scanner := bufio.NewScanner(bytes.NewReader(expectedContent))
@@ -160,7 +160,7 @@ func TestFalco_Legacy_ListAppendFalse(t *testing.T) {
 		falco.WithCaptureFile(captures.CatWrite),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_MacroAppend(t *testing.T) {
@@ -177,7 +177,7 @@ func TestFalco_Legacy_MacroAppend(t *testing.T) {
 	assert.NotZero(t, res.Detections().Count())
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_ListSubstring(t *testing.T) {
@@ -189,7 +189,7 @@ func TestFalco_Legacy_ListSubstring(t *testing.T) {
 		falco.WithCaptureFile(captures.CatWrite),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_InvalidNotArray(t *testing.T) {
@@ -205,7 +205,7 @@ func TestFalco_Legacy_InvalidNotArray(t *testing.T) {
 		OfItemType("rules content").
 		OfMessage("Rules content is not yaml array of objects"))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_InvalidEngineVersionNotNumber(t *testing.T) {
@@ -221,7 +221,7 @@ func TestFalco_Legacy_InvalidEngineVersionNotNumber(t *testing.T) {
 		OfItemType("required_engine_version").
 		OfMessage("Unable to parse engine version 'not-a-number' as a semver string. Expected \"x.y.z\" semver format."), res.Stdout())
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_InvalidOverwriteRuleMultipleDocs(t *testing.T) {
@@ -238,7 +238,7 @@ func TestFalco_Legacy_InvalidOverwriteRuleMultipleDocs(t *testing.T) {
 		OfItemName("some rule").
 		OfMessage("Undefined macro 'bar' used in filter."))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_DisabledRulesUsingSubstring(t *testing.T) {
@@ -251,7 +251,7 @@ func TestFalco_Legacy_DisabledRulesUsingSubstring(t *testing.T) {
 		falco.WithCaptureFile(captures.CatWrite),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_DetectSkipUnknownNoevt(t *testing.T) {
@@ -266,7 +266,7 @@ func TestFalco_Legacy_DetectSkipUnknownNoevt(t *testing.T) {
 	assert.Equal(t, 4, res.Detections().Count())
 	assert.NotZero(t, res.Detections().OfPriority("INFO").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_ListAppend(t *testing.T) {
@@ -283,7 +283,7 @@ func TestFalco_Legacy_ListAppend(t *testing.T) {
 	assert.NotZero(t, res.Detections().Count())
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleAppendSkipped(t *testing.T) {
@@ -296,7 +296,7 @@ func TestFalco_Legacy_RuleAppendSkipped(t *testing.T) {
 		falco.WithCaptureFile(captures.CatWrite),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_SkipUnknownError(t *testing.T) {
@@ -314,7 +314,7 @@ func TestFalco_Legacy_SkipUnknownError(t *testing.T) {
 		OfItemName("Contains Unknown Event And Not Skipping (field)").
 		OfMessage("filter_check called with nonexistent field proc.nobody"))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_MultipleRulesOverriding(t *testing.T) {
@@ -326,7 +326,7 @@ func TestFalco_Legacy_MultipleRulesOverriding(t *testing.T) {
 		falco.WithCaptureFile(captures.CatWrite),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_InvalidAppendMacro(t *testing.T) {
@@ -349,7 +349,7 @@ func TestFalco_Legacy_InvalidAppendMacro(t *testing.T) {
 		OfItemName("some_macro").
 		OfMessage("Macro not referred to by any other rule/macro"))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_InvalidMissingListName(t *testing.T) {
@@ -365,7 +365,7 @@ func TestFalco_Legacy_InvalidMissingListName(t *testing.T) {
 		OfItemType("list").
 		OfMessage("Mapping for key 'list' is empty"))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_DisabledTagsB(t *testing.T) {
@@ -396,7 +396,7 @@ func TestFalco_Legacy_DisabledTagsB(t *testing.T) {
 	assert.Equal(t, 1, res.Detections().OfRule("open_12").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("open_13").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RunTagsC(t *testing.T) {
@@ -427,7 +427,7 @@ func TestFalco_Legacy_RunTagsC(t *testing.T) {
 	assert.Equal(t, 0, res.Detections().OfRule("open_12").Count())
 	assert.Equal(t, 0, res.Detections().OfRule("open_13").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RunTagsAbc(t *testing.T) {
@@ -458,7 +458,7 @@ func TestFalco_Legacy_RunTagsAbc(t *testing.T) {
 	assert.Equal(t, 0, res.Detections().OfRule("open_12").Count())
 	assert.Equal(t, 0, res.Detections().OfRule("open_13").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleAppend(t *testing.T) {
@@ -475,7 +475,7 @@ func TestFalco_Legacy_RuleAppend(t *testing.T) {
 	assert.NotZero(t, res.Detections().Count())
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_ListOverriding(t *testing.T) {
@@ -487,7 +487,7 @@ func TestFalco_Legacy_ListOverriding(t *testing.T) {
 		falco.WithCaptureFile(captures.CatWrite),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_ListSubBare(t *testing.T) {
@@ -504,7 +504,7 @@ func TestFalco_Legacy_ListSubBare(t *testing.T) {
 	assert.NotZero(t, res.Detections().Count())
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_InvalidOverwriteMacroMultipleDocs(t *testing.T) {
@@ -521,7 +521,7 @@ func TestFalco_Legacy_InvalidOverwriteMacroMultipleDocs(t *testing.T) {
 		OfItemName("some_macro").
 		OfMessage("Undefined macro 'foo' used in filter."))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_DisabledTagsA(t *testing.T) {
@@ -552,7 +552,7 @@ func TestFalco_Legacy_DisabledTagsA(t *testing.T) {
 	assert.Equal(t, 1, res.Detections().OfRule("open_12").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("open_13").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_InvalidYamlParseError(t *testing.T) {
@@ -568,7 +568,7 @@ func TestFalco_Legacy_InvalidYamlParseError(t *testing.T) {
 		OfItemType("rules content").
 		OfMessage("yaml-cpp: error at line 1, column 11: illegal map value"))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_InvalidRuleWithoutOutput(t *testing.T) {
@@ -585,7 +585,7 @@ func TestFalco_Legacy_InvalidRuleWithoutOutput(t *testing.T) {
 		OfItemName("no output rule").
 		OfMessage("Item has no mapping for key 'output'"))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_Syscalls(t *testing.T) {
@@ -605,7 +605,7 @@ func TestFalco_Legacy_Syscalls(t *testing.T) {
 	assert.Equal(t, 2, res.Detections().OfRule("detect_madvise").Count())
 	assert.Equal(t, 2, res.Detections().OfRule("detect_open").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_BuiltinRulesNoWarnings(t *testing.T) {
@@ -617,7 +617,7 @@ func TestFalco_Legacy_BuiltinRulesNoWarnings(t *testing.T) {
 		falco.WithCaptureFile(captures.Empty),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RunTagsA(t *testing.T) {
@@ -648,7 +648,7 @@ func TestFalco_Legacy_RunTagsA(t *testing.T) {
 	assert.Equal(t, 0, res.Detections().OfRule("open_12").Count())
 	assert.Equal(t, 0, res.Detections().OfRule("open_13").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_MonitorSyscallDropsNone(t *testing.T) {
@@ -664,7 +664,7 @@ func TestFalco_Legacy_MonitorSyscallDropsNone(t *testing.T) {
 	assert.NotRegexp(t, `Falco internal: syscall event drop`, res.Stderr())
 	assert.NotRegexp(t, `Falco internal: syscall event drop`, res.Stdout())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_MonitorSyscallDropsIgnore(t *testing.T) {
@@ -680,7 +680,7 @@ func TestFalco_Legacy_MonitorSyscallDropsIgnore(t *testing.T) {
 	assert.NotRegexp(t, `Falco internal: syscall event drop`, res.Stderr())
 	assert.NotRegexp(t, `Falco internal: syscall event drop`, res.Stdout())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_MonitorSyscallDropsThresholdOor(t *testing.T) {
@@ -697,7 +697,7 @@ func TestFalco_Legacy_MonitorSyscallDropsThresholdOor(t *testing.T) {
 	assert.NotRegexp(t, `Falco internal: syscall event drop`, res.Stderr())
 	assert.NotRegexp(t, `Falco internal: syscall event drop`, res.Stdout())
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_MultipleRulesSuppressInfo(t *testing.T) {
@@ -720,7 +720,7 @@ func TestFalco_Legacy_MultipleRulesSuppressInfo(t *testing.T) {
 	assert.Equal(t, 1, res.Detections().OfRule("exec_from_cat").Count())
 	assert.Equal(t, 0, res.Detections().OfRule("access_from_cat").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_ListSubMid(t *testing.T) {
@@ -737,7 +737,7 @@ func TestFalco_Legacy_ListSubMid(t *testing.T) {
 	assert.NotZero(t, res.Detections().Count())
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_InvalidListWithoutItems(t *testing.T) {
@@ -754,7 +754,7 @@ func TestFalco_Legacy_InvalidListWithoutItems(t *testing.T) {
 		OfItemName("bad_list").
 		OfMessage("Item has no mapping for key 'items'"))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_DisabledRulesUsingEnabledFlag(t *testing.T) {
@@ -766,7 +766,7 @@ func TestFalco_Legacy_DisabledRulesUsingEnabledFlag(t *testing.T) {
 		falco.WithCaptureFile(captures.CatWrite),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_DisabledRuleUsingFalseEnabledFlagOnly(t *testing.T) {
@@ -778,7 +778,7 @@ func TestFalco_Legacy_DisabledRuleUsingFalseEnabledFlagOnly(t *testing.T) {
 		falco.WithCaptureFile(captures.CatWrite),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_InvalidRuleOutput(t *testing.T) {
@@ -795,7 +795,7 @@ func TestFalco_Legacy_InvalidRuleOutput(t *testing.T) {
 		OfItemName("rule_with_invalid_output").
 		OfMessage(regexp.MustCompile(`(invalid formatting token not_a_real_field|unknown filter:.*unexpected token)`)))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_FileOutputStrict(t *testing.T) {
@@ -817,7 +817,7 @@ func TestFalco_Legacy_FileOutputStrict(t *testing.T) {
 		assert.Nil(t, err1)
 		assert.Nil(t, err2)
 		assert.Equal(t, string(expectedContent), string(actualContent))
-		assert.Equal(t, 0, res.ExitCode())
+		assert.Zero(t, res.ExitCode(), res.ExitDesc())
 	})
 }
 
@@ -849,7 +849,7 @@ func TestFalco_Legacy_RunTagsBc(t *testing.T) {
 	assert.Equal(t, 0, res.Detections().OfRule("open_12").Count())
 	assert.Equal(t, 0, res.Detections().OfRule("open_13").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_MonitorSyscallDropsIgnoreAndLog(t *testing.T) {
@@ -866,7 +866,7 @@ func TestFalco_Legacy_MonitorSyscallDropsIgnoreAndLog(t *testing.T) {
 	assert.NotRegexp(t, `Falco internal: syscall event drop`, res.Stderr())
 	assert.NotRegexp(t, `Falco internal: syscall event drop`, res.Stdout())
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_MonitorSyscallDropsThresholdNeg(t *testing.T) {
@@ -883,7 +883,7 @@ func TestFalco_Legacy_MonitorSyscallDropsThresholdNeg(t *testing.T) {
 	assert.NotRegexp(t, `Falco internal: syscall event drop`, res.Stderr())
 	assert.NotRegexp(t, `Falco internal: syscall event drop`, res.Stdout())
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_MultipleRulesLastEmpty(t *testing.T) {
@@ -900,7 +900,7 @@ func TestFalco_Legacy_MultipleRulesLastEmpty(t *testing.T) {
 	assert.NotZero(t, res.Detections().Count())
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_ListSubWhitespace(t *testing.T) {
@@ -917,7 +917,7 @@ func TestFalco_Legacy_ListSubWhitespace(t *testing.T) {
 	assert.NotZero(t, res.Detections().Count())
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_InvalidMacroWithoutCondition(t *testing.T) {
@@ -934,7 +934,7 @@ func TestFalco_Legacy_InvalidMacroWithoutCondition(t *testing.T) {
 		OfItemName("bad_macro").
 		OfMessage("Item has no mapping for key 'condition'"))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_CatchallOrder(t *testing.T) {
@@ -953,7 +953,7 @@ func TestFalco_Legacy_CatchallOrder(t *testing.T) {
 	assert.Equal(t, 1, res.Detections().OfRule("open_dev_null").Count())
 	assert.Equal(t, 3, res.Detections().OfRule("dev_null").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_ListSubFront(t *testing.T) {
@@ -970,7 +970,7 @@ func TestFalco_Legacy_ListSubFront(t *testing.T) {
 	assert.NotZero(t, res.Detections().Count())
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_ListOrder(t *testing.T) {
@@ -987,7 +987,7 @@ func TestFalco_Legacy_ListOrder(t *testing.T) {
 	assert.NotZero(t, res.Detections().Count())
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_InvalidMissingMacroName(t *testing.T) {
@@ -1003,7 +1003,7 @@ func TestFalco_Legacy_InvalidMissingMacroName(t *testing.T) {
 		OfItemType("macro").
 		OfMessage("Mapping for key 'macro' is empty"))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_DisabledTagsAbc(t *testing.T) {
@@ -1034,7 +1034,7 @@ func TestFalco_Legacy_DisabledTagsAbc(t *testing.T) {
 	assert.Equal(t, 1, res.Detections().OfRule("open_12").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("open_13").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_SkipUnknownPrefix(t *testing.T) {
@@ -1046,7 +1046,7 @@ func TestFalco_Legacy_SkipUnknownPrefix(t *testing.T) {
 		falco.WithCaptureFile(captures.CatWrite),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_MonitorSyscallDropsLog(t *testing.T) {
@@ -1062,7 +1062,7 @@ func TestFalco_Legacy_MonitorSyscallDropsLog(t *testing.T) {
 	assert.Regexp(t, `Falco internal: syscall event drop`, res.Stderr())
 	assert.NotRegexp(t, `Falco internal: syscall event drop`, res.Stdout())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_InvalidOverwriteRule(t *testing.T) {
@@ -1080,7 +1080,7 @@ func TestFalco_Legacy_InvalidOverwriteRule(t *testing.T) {
 		OfItemName("some rule").
 		OfMessage("Undefined macro 'bar' used in filter."))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_DisabledTagsC(t *testing.T) {
@@ -1111,7 +1111,7 @@ func TestFalco_Legacy_DisabledTagsC(t *testing.T) {
 	assert.Equal(t, 1, res.Detections().OfRule("open_12").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("open_13").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RunTagsD(t *testing.T) {
@@ -1142,7 +1142,7 @@ func TestFalco_Legacy_RunTagsD(t *testing.T) {
 	assert.Equal(t, 0, res.Detections().OfRule("open_12").Count())
 	assert.Equal(t, 0, res.Detections().OfRule("open_13").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_MacroAppendFalse(t *testing.T) {
@@ -1154,7 +1154,7 @@ func TestFalco_Legacy_MacroAppendFalse(t *testing.T) {
 		falco.WithCaptureFile(captures.CatWrite),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_InvalidAppendMacroMultipleDocs(t *testing.T) {
@@ -1171,7 +1171,7 @@ func TestFalco_Legacy_InvalidAppendMacroMultipleDocs(t *testing.T) {
 		OfItemName("some_macro").
 		OfMessage("unexpected token after 'execve', expecting 'or', 'and'"))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_DisabledRules(t *testing.T) {
@@ -1184,7 +1184,7 @@ func TestFalco_Legacy_DisabledRules(t *testing.T) {
 		falco.WithCaptureFile(captures.CatWrite),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_MultipleRules(t *testing.T) {
@@ -1204,7 +1204,7 @@ func TestFalco_Legacy_MultipleRules(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("INFO").Count())
 	assert.NotZero(t, res.Detections().OfPriority("ERROR").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_MultipleDocs(t *testing.T) {
@@ -1224,7 +1224,7 @@ func TestFalco_Legacy_MultipleDocs(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("INFO").Count())
 	assert.NotZero(t, res.Detections().OfPriority("ERROR").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_NestedListOverriding(t *testing.T) {
@@ -1236,7 +1236,7 @@ func TestFalco_Legacy_NestedListOverriding(t *testing.T) {
 		falco.WithCaptureFile(captures.CatWrite),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_MacroOrder(t *testing.T) {
@@ -1253,7 +1253,7 @@ func TestFalco_Legacy_MacroOrder(t *testing.T) {
 	assert.NotZero(t, res.Detections().Count())
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_InvalidAppendRuleWithoutCondition(t *testing.T) {
@@ -1270,7 +1270,7 @@ func TestFalco_Legacy_InvalidAppendRuleWithoutCondition(t *testing.T) {
 		OfItemName("no condition rule").
 		OfMessage("Appended rule must have exceptions or condition property"))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_SkipUnknownUnspecError(t *testing.T) {
@@ -1287,7 +1287,7 @@ func TestFalco_Legacy_SkipUnknownUnspecError(t *testing.T) {
 		OfItemName("Contains Unknown Event And Unspecified").
 		OfMessage("filter_check called with nonexistent field proc.nobody"))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_MonitorSyscallDropsAlert(t *testing.T) {
@@ -1303,7 +1303,7 @@ func TestFalco_Legacy_MonitorSyscallDropsAlert(t *testing.T) {
 	assert.NotRegexp(t, `Falco internal: syscall event drop`, res.Stderr())
 	assert.Regexp(t, `Falco internal: syscall event drop`, res.Stdout())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_MonitorSyscallDropsExit(t *testing.T) {
@@ -1320,7 +1320,7 @@ func TestFalco_Legacy_MonitorSyscallDropsExit(t *testing.T) {
 	assert.Regexp(t, `Exiting.`, res.Stderr())
 	assert.NotRegexp(t, `Falco internal: syscall event drop`, res.Stdout())
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_DisabledTagsAb(t *testing.T) {
@@ -1351,7 +1351,7 @@ func TestFalco_Legacy_DisabledTagsAb(t *testing.T) {
 	assert.Equal(t, 1, res.Detections().OfRule("open_12").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("open_13").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RunTagsB(t *testing.T) {
@@ -1382,7 +1382,7 @@ func TestFalco_Legacy_RunTagsB(t *testing.T) {
 	assert.Equal(t, 0, res.Detections().OfRule("open_12").Count())
 	assert.Equal(t, 0, res.Detections().OfRule("open_13").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleAppendFalse(t *testing.T) {
@@ -1394,7 +1394,7 @@ func TestFalco_Legacy_RuleAppendFalse(t *testing.T) {
 		falco.WithCaptureFile(captures.CatWrite),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleOrder(t *testing.T) {
@@ -1411,7 +1411,7 @@ func TestFalco_Legacy_RuleOrder(t *testing.T) {
 	assert.NotZero(t, res.Detections().Count())
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_InvalidNotYaml(t *testing.T) {
@@ -1427,7 +1427,7 @@ func TestFalco_Legacy_InvalidNotYaml(t *testing.T) {
 		OfItemType("rules content").
 		OfMessage("Rules content is not yaml"))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_InvalidOverwriteMacro(t *testing.T) {
@@ -1450,7 +1450,7 @@ func TestFalco_Legacy_InvalidOverwriteMacro(t *testing.T) {
 		OfItemName("some_macro").
 		OfMessage("Macro not referred to by any other rule/macro"))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_InvalidMissingRuleName(t *testing.T) {
@@ -1466,7 +1466,7 @@ func TestFalco_Legacy_InvalidMissingRuleName(t *testing.T) {
 		OfItemType("rule").
 		OfMessage("Mapping for key 'rule' is empty"))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleNamesWithSpaces(t *testing.T) {
@@ -1483,7 +1483,7 @@ func TestFalco_Legacy_RuleNamesWithSpaces(t *testing.T) {
 	assert.NotZero(t, res.Detections().Count())
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_MultipleRulesFirstEmpty(t *testing.T) {
@@ -1500,7 +1500,7 @@ func TestFalco_Legacy_MultipleRulesFirstEmpty(t *testing.T) {
 	assert.NotZero(t, res.Detections().Count())
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_ProgramOutputStrict(t *testing.T) {
@@ -1515,7 +1515,7 @@ func TestFalco_Legacy_ProgramOutputStrict(t *testing.T) {
 		falco.WithArgs("-o", "stdout_output.enabled=false"),
 	)
 
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 	expectedContent, err := outputs.SingleRuleWithCatWriteText.Content()
 	assert.Nil(t, err)
 	scanner := bufio.NewScanner(bytes.NewReader(expectedContent))
@@ -1541,7 +1541,7 @@ func TestFalco_Legacy_InvalidAppendRule(t *testing.T) {
 		OfItemName("some rule").
 		OfMessage("unexpected token after 'open', expecting 'or', 'and'"))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_InvalidAppendRuleMultipleDocs(t *testing.T) {
@@ -1558,7 +1558,7 @@ func TestFalco_Legacy_InvalidAppendRuleMultipleDocs(t *testing.T) {
 		OfItemName("some rule").
 		OfMessage("unexpected token after 'open', expecting 'or', 'and'"))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RunTagsAb(t *testing.T) {
@@ -1589,7 +1589,7 @@ func TestFalco_Legacy_RunTagsAb(t *testing.T) {
 	assert.Equal(t, 0, res.Detections().OfRule("open_12").Count())
 	assert.Equal(t, 0, res.Detections().OfRule("open_13").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_ValidateSkipUnknownNoevt(t *testing.T) {
@@ -1614,7 +1614,7 @@ func TestFalco_Legacy_ValidateSkipUnknownNoevt(t *testing.T) {
 		OfItemName("Contains Unknown Event And Skipping (output)").
 		OfMessage(regexp.MustCompile(`(invalid formatting token proc\.nobody|unknown filter:.*unexpected token)`)), res.Stderr())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_ListSubEnd(t *testing.T) {
@@ -1631,7 +1631,7 @@ func TestFalco_Legacy_ListSubEnd(t *testing.T) {
 	assert.NotZero(t, res.Detections().Count())
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_InvalidArrayItemNotObject(t *testing.T) {
@@ -1647,7 +1647,7 @@ func TestFalco_Legacy_InvalidArrayItemNotObject(t *testing.T) {
 		OfItemType("rules content item").
 		OfMessage("Unexpected element type. Each element should be a yaml associative array."))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleExceptionSecondItem(t *testing.T) {
@@ -1664,7 +1664,7 @@ func TestFalco_Legacy_RuleExceptionSecondItem(t *testing.T) {
 	assert.Zero(t, res.Detections().Count())
 	assert.Zero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleExceptionAppendMultipleValues(t *testing.T) {
@@ -1681,7 +1681,7 @@ func TestFalco_Legacy_RuleExceptionAppendMultipleValues(t *testing.T) {
 	assert.Zero(t, res.Detections().Count())
 	assert.Zero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleExceptionAppendComp(t *testing.T) {
@@ -1698,7 +1698,7 @@ func TestFalco_Legacy_RuleExceptionAppendComp(t *testing.T) {
 	assert.Zero(t, res.Detections().Count())
 	assert.Zero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleExceptionSingleField(t *testing.T) {
@@ -1715,7 +1715,7 @@ func TestFalco_Legacy_RuleExceptionSingleField(t *testing.T) {
 	assert.Zero(t, res.Detections().Count())
 	assert.Zero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleExceptionNewAppendNoField(t *testing.T) {
@@ -1732,7 +1732,7 @@ func TestFalco_Legacy_RuleExceptionNewAppendNoField(t *testing.T) {
 		OfItemName("proc_cmdline").
 		OfMessage("Rule exception must have fields property with a list of fields"))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleExceptionAppendOneValue(t *testing.T) {
@@ -1749,7 +1749,7 @@ func TestFalco_Legacy_RuleExceptionAppendOneValue(t *testing.T) {
 	assert.Zero(t, res.Detections().Count())
 	assert.Zero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleExceptionQuoted(t *testing.T) {
@@ -1766,7 +1766,7 @@ func TestFalco_Legacy_RuleExceptionQuoted(t *testing.T) {
 	assert.Zero(t, res.Detections().Count())
 	assert.Zero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleExceptionAppendThirdItem(t *testing.T) {
@@ -1783,7 +1783,7 @@ func TestFalco_Legacy_RuleExceptionAppendThirdItem(t *testing.T) {
 	assert.Zero(t, res.Detections().Count())
 	assert.Zero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleExceptionSingleFieldAppend(t *testing.T) {
@@ -1800,7 +1800,7 @@ func TestFalco_Legacy_RuleExceptionSingleFieldAppend(t *testing.T) {
 	assert.Zero(t, res.Detections().Count())
 	assert.Zero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleExceptionNewSingleFieldAppend(t *testing.T) {
@@ -1817,7 +1817,7 @@ func TestFalco_Legacy_RuleExceptionNewSingleFieldAppend(t *testing.T) {
 	assert.Zero(t, res.Detections().Count())
 	assert.Zero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleExceptionUnknownFields(t *testing.T) {
@@ -1834,7 +1834,7 @@ func TestFalco_Legacy_RuleExceptionUnknownFields(t *testing.T) {
 		OfItemName("ex1").
 		OfMessage("'not.exist' is not a supported filter field"))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleExceptionSecondValue(t *testing.T) {
@@ -1851,7 +1851,7 @@ func TestFalco_Legacy_RuleExceptionSecondValue(t *testing.T) {
 	assert.Zero(t, res.Detections().Count())
 	assert.Zero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleExceptionValuesList(t *testing.T) {
@@ -1868,7 +1868,7 @@ func TestFalco_Legacy_RuleExceptionValuesList(t *testing.T) {
 	assert.Zero(t, res.Detections().Count())
 	assert.Zero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleExceptionAppendFieldsValuesLenMismatch(t *testing.T) {
@@ -1885,7 +1885,7 @@ func TestFalco_Legacy_RuleExceptionAppendFieldsValuesLenMismatch(t *testing.T) {
 		OfItemName("ex1").
 		OfMessage("Fields and values lists must have equal length"))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleExceptionAppendItemNotInRule(t *testing.T) {
@@ -1902,7 +1902,7 @@ func TestFalco_Legacy_RuleExceptionAppendItemNotInRule(t *testing.T) {
 		OfItemName("ex2").
 		OfMessage("Rule exception must have fields property with a list of fields"))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleExceptionThirdItem(t *testing.T) {
@@ -1919,7 +1919,7 @@ func TestFalco_Legacy_RuleExceptionThirdItem(t *testing.T) {
 	assert.Zero(t, res.Detections().Count())
 	assert.Zero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleExceptionNoFields(t *testing.T) {
@@ -1936,7 +1936,7 @@ func TestFalco_Legacy_RuleExceptionNoFields(t *testing.T) {
 		OfItemName("ex1").
 		OfMessage("Item has no mapping for key 'fields'"))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleExceptionAppendNoName(t *testing.T) {
@@ -1952,7 +1952,7 @@ func TestFalco_Legacy_RuleExceptionAppendNoName(t *testing.T) {
 		OfItemType("exception").
 		OfMessage("Item has no mapping for key 'name'"))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleExceptionCompsFieldsLenMismatch(t *testing.T) {
@@ -1969,7 +1969,7 @@ func TestFalco_Legacy_RuleExceptionCompsFieldsLenMismatch(t *testing.T) {
 		OfItemName("ex1").
 		OfMessage("Fields and comps lists must have equal length"))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleExceptionNoValues(t *testing.T) {
@@ -1986,7 +1986,7 @@ func TestFalco_Legacy_RuleExceptionNoValues(t *testing.T) {
 	assert.NotZero(t, res.Detections().Count())
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleExceptionAppendSecondValue(t *testing.T) {
@@ -2003,7 +2003,7 @@ func TestFalco_Legacy_RuleExceptionAppendSecondValue(t *testing.T) {
 	assert.Zero(t, res.Detections().Count())
 	assert.Zero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleExceptionNoName(t *testing.T) {
@@ -2019,7 +2019,7 @@ func TestFalco_Legacy_RuleExceptionNoName(t *testing.T) {
 		OfItemType("exception").
 		OfMessage("Item has no mapping for key 'name'"))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleExceptionComp(t *testing.T) {
@@ -2036,7 +2036,7 @@ func TestFalco_Legacy_RuleExceptionComp(t *testing.T) {
 	assert.Zero(t, res.Detections().Count())
 	assert.Zero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleExceptionValuesListref(t *testing.T) {
@@ -2053,7 +2053,7 @@ func TestFalco_Legacy_RuleExceptionValuesListref(t *testing.T) {
 	assert.Zero(t, res.Detections().Count())
 	assert.Zero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleExceptionNewSecondFieldAppend(t *testing.T) {
@@ -2070,7 +2070,7 @@ func TestFalco_Legacy_RuleExceptionNewSecondFieldAppend(t *testing.T) {
 	assert.Zero(t, res.Detections().Count())
 	assert.Zero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleExceptionUnknownComp(t *testing.T) {
@@ -2087,7 +2087,7 @@ func TestFalco_Legacy_RuleExceptionUnknownComp(t *testing.T) {
 		OfItemName("ex1").
 		OfMessage("'no-comp' is not a supported comparison operator"))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleExceptionFieldsValuesLenMismatch(t *testing.T) {
@@ -2104,7 +2104,7 @@ func TestFalco_Legacy_RuleExceptionFieldsValuesLenMismatch(t *testing.T) {
 		OfItemName("ex1").
 		OfMessage("Fields and values lists must have equal length"))
 	assert.Error(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 1, res.ExitCode())
+	assert.Equal(t, 1, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleExceptionOneValue(t *testing.T) {
@@ -2121,7 +2121,7 @@ func TestFalco_Legacy_RuleExceptionOneValue(t *testing.T) {
 	assert.Zero(t, res.Detections().Count())
 	assert.Zero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleExceptionAppendSecondItem(t *testing.T) {
@@ -2138,7 +2138,7 @@ func TestFalco_Legacy_RuleExceptionAppendSecondItem(t *testing.T) {
 	assert.Zero(t, res.Detections().Count())
 	assert.Zero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleExceptionValuesListrefNoparens(t *testing.T) {
@@ -2155,7 +2155,7 @@ func TestFalco_Legacy_RuleExceptionValuesListrefNoparens(t *testing.T) {
 	assert.Zero(t, res.Detections().Count())
 	assert.Zero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_ReadSensitiveFileUntrusted(t *testing.T) {
@@ -2173,7 +2173,7 @@ func TestFalco_Legacy_ReadSensitiveFileUntrusted(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("Read sensitive file untrusted").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_KernelUpgrade(t *testing.T) {
@@ -2190,7 +2190,7 @@ func TestFalco_Legacy_KernelUpgrade(t *testing.T) {
 	assert.Zero(t, res.Detections().Count())
 	assert.Zero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_CreateFilesBelowDev(t *testing.T) {
@@ -2208,7 +2208,7 @@ func TestFalco_Legacy_CreateFilesBelowDev(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("ERROR").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("Create files below dev").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_ReadSensitiveFileAfterStartup(t *testing.T) {
@@ -2227,7 +2227,7 @@ func TestFalco_Legacy_ReadSensitiveFileAfterStartup(t *testing.T) {
 	assert.Equal(t, 1, res.Detections().OfRule("Read sensitive file untrusted").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("Read sensitive file trusted after startup").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RunShellUntrusted(t *testing.T) {
@@ -2245,7 +2245,7 @@ func TestFalco_Legacy_RunShellUntrusted(t *testing.T) {
 	assert.Zero(t, res.Detections().OfPriority("DEBUG").Count())
 	assert.Equal(t, 0, res.Detections().OfRule("Run shell untrusted").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_ChangeThreadNamespace(t *testing.T) {
@@ -2263,7 +2263,7 @@ func TestFalco_Legacy_ChangeThreadNamespace(t *testing.T) {
 	assert.Zero(t, res.Detections().OfPriority("NOTICE").Count())
 	assert.Equal(t, 0, res.Detections().OfRule("Change thread namespace").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_MkdirBinaryDirs(t *testing.T) {
@@ -2281,7 +2281,7 @@ func TestFalco_Legacy_MkdirBinaryDirs(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("ERROR").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("Mkdir binary dirs").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_SystemBinariesNetworkActivity(t *testing.T) {
@@ -2299,7 +2299,7 @@ func TestFalco_Legacy_SystemBinariesNetworkActivity(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("NOTICE").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("System procs network activity").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_WriteRpmDatabase(t *testing.T) {
@@ -2317,7 +2317,7 @@ func TestFalco_Legacy_WriteRpmDatabase(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("ERROR").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("Write below rpm database").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_DockerCompose(t *testing.T) {
@@ -2336,7 +2336,7 @@ func TestFalco_Legacy_DockerCompose(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("NOTICE").Count())
 	assert.Equal(t, 2, res.Detections().OfRule("Redirect STDOUT/STDIN to Network Connection in Container").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_CurlUninstall(t *testing.T) {
@@ -2353,7 +2353,7 @@ func TestFalco_Legacy_CurlUninstall(t *testing.T) {
 	assert.Zero(t, res.Detections().Count())
 	assert.Zero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_DhcpclientRenew(t *testing.T) {
@@ -2370,7 +2370,7 @@ func TestFalco_Legacy_DhcpclientRenew(t *testing.T) {
 	assert.Zero(t, res.Detections().Count())
 	assert.Zero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_StagingWorker(t *testing.T) {
@@ -2387,7 +2387,7 @@ func TestFalco_Legacy_StagingWorker(t *testing.T) {
 	assert.Zero(t, res.Detections().Count())
 	assert.Zero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_DbProgramSpawnedProcess(t *testing.T) {
@@ -2406,7 +2406,7 @@ func TestFalco_Legacy_DbProgramSpawnedProcess(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("NOTICE").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("DB program spawned process").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_UserMgmtBinaries(t *testing.T) {
@@ -2425,7 +2425,7 @@ func TestFalco_Legacy_UserMgmtBinaries(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("NOTICE").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("User mgmt binaries").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_Exim4(t *testing.T) {
@@ -2442,7 +2442,7 @@ func TestFalco_Legacy_Exim4(t *testing.T) {
 	assert.Zero(t, res.Detections().Count())
 	assert.Zero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_WriteEtc(t *testing.T) {
@@ -2460,7 +2460,7 @@ func TestFalco_Legacy_WriteEtc(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("ERROR").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("Write below etc").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_StagingCollector(t *testing.T) {
@@ -2477,7 +2477,7 @@ func TestFalco_Legacy_StagingCollector(t *testing.T) {
 	assert.Zero(t, res.Detections().Count())
 	assert.Zero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_ContainerPrivileged(t *testing.T) {
@@ -2496,7 +2496,7 @@ func TestFalco_Legacy_ContainerPrivileged(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("INFO").Count())
 	assert.Equal(t, 3, res.Detections().OfRule("Launch Privileged Container").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_ContainerSensitiveMount(t *testing.T) {
@@ -2515,7 +2515,7 @@ func TestFalco_Legacy_ContainerSensitiveMount(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("INFO").Count())
 	assert.Equal(t, 3, res.Detections().OfRule("Launch Sensitive Mount Container").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_WriteBinaryDir(t *testing.T) {
@@ -2533,7 +2533,7 @@ func TestFalco_Legacy_WriteBinaryDir(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("ERROR").Count())
 	assert.Equal(t, 4, res.Detections().OfRule("Write below binary dir").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_CurlInstall(t *testing.T) {
@@ -2550,7 +2550,7 @@ func TestFalco_Legacy_CurlInstall(t *testing.T) {
 	assert.Zero(t, res.Detections().Count())
 	assert.Zero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_StagingDb(t *testing.T) {
@@ -2567,7 +2567,7 @@ func TestFalco_Legacy_StagingDb(t *testing.T) {
 	assert.Zero(t, res.Detections().Count())
 	assert.Zero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_ModifyBinaryDirs(t *testing.T) {
@@ -2585,7 +2585,7 @@ func TestFalco_Legacy_ModifyBinaryDirs(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("ERROR").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("Modify binary dirs").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_NonSudoSetuid(t *testing.T) {
@@ -2601,7 +2601,7 @@ func TestFalco_Legacy_NonSudoSetuid(t *testing.T) {
 	)
 	assert.Equal(t, 0, res.Detections().OfRule("Non sudo setuid").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_GitPush(t *testing.T) {
@@ -2618,7 +2618,7 @@ func TestFalco_Legacy_GitPush(t *testing.T) {
 	assert.Zero(t, res.Detections().Count())
 	assert.Zero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_KubeDemo(t *testing.T) {
@@ -2638,7 +2638,7 @@ func TestFalco_Legacy_KubeDemo(t *testing.T) {
 	assert.Zero(t, res.Detections().Count())
 	assert.Zero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_FalcoEventGenerator(t *testing.T) {
@@ -2670,7 +2670,7 @@ func TestFalco_Legacy_FalcoEventGenerator(t *testing.T) {
 	assert.Equal(t, 2, res.Detections().OfRule("Modify binary dirs").Count())
 	assert.Equal(t, 0, res.Detections().OfRule("Change thread namespace").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_SystemUserInteractive(t *testing.T) {
@@ -2689,7 +2689,7 @@ func TestFalco_Legacy_SystemUserInteractive(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("INFO").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("System user interactive").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RuleNamesWithRegexChars(t *testing.T) {
@@ -2708,7 +2708,7 @@ func TestFalco_Legacy_RuleNamesWithRegexChars(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.Equal(t, 4, res.Detections().OfRule(`Open From Cat ($\.*+?()[]{}|^)`).Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_JsonOutputNoOutputProperty(t *testing.T) {
@@ -2726,7 +2726,7 @@ func TestFalco_Legacy_JsonOutputNoOutputProperty(t *testing.T) {
 	assert.NotZero(t, res.Detections().Count())
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_JsonOutputNoTagsProperty(t *testing.T) {
@@ -2744,7 +2744,7 @@ func TestFalco_Legacy_JsonOutputNoTagsProperty(t *testing.T) {
 	assert.NotZero(t, res.Detections().Count())
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_JsonOutputEmptyTagsProperty(t *testing.T) {
@@ -2762,7 +2762,7 @@ func TestFalco_Legacy_JsonOutputEmptyTagsProperty(t *testing.T) {
 	assert.NotZero(t, res.Detections().Count())
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_RulesDirectory(t *testing.T) {
@@ -2782,7 +2782,7 @@ func TestFalco_Legacy_RulesDirectory(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("INFO").Count())
 	assert.NotZero(t, res.Detections().OfPriority("ERROR").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_EnabledRuleUsingFalseEnabledFlagOnly(t *testing.T) {
@@ -2800,7 +2800,7 @@ func TestFalco_Legacy_EnabledRuleUsingFalseEnabledFlagOnly(t *testing.T) {
 	assert.Equal(t, 4, res.Detections().OfRule("open_from_cat").Count())
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_NullOutputField(t *testing.T) {
@@ -2818,7 +2818,7 @@ func TestFalco_Legacy_NullOutputField(t *testing.T) {
 	assert.NotZero(t, res.Detections().Count())
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_InOperatorNetmasks(t *testing.T) {
@@ -2835,7 +2835,7 @@ func TestFalco_Legacy_InOperatorNetmasks(t *testing.T) {
 	assert.NotZero(t, res.Detections().Count())
 	assert.NotZero(t, res.Detections().OfPriority("INFO").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_TimeIso8601(t *testing.T) {
@@ -2855,7 +2855,7 @@ func TestFalco_Legacy_TimeIso8601(t *testing.T) {
 	assert.NotZero(t, res.Detections().Count())
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_TestWarnings(t *testing.T) {
@@ -2867,7 +2867,7 @@ func TestFalco_Legacy_TestWarnings(t *testing.T) {
 		falco.WithRulesValidation(rules.FalcoRulesWarnings),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 	assert.True(t, res.RuleValidation().At(0).Successful)
 	warnings := res.RuleValidation().AllWarnings().
 		OfCode("LOAD_NO_EVTTYPE").
@@ -2898,7 +2898,7 @@ func TestFalco_Legacy_NoPluginsUnknownSource(t *testing.T) {
 		OfItemName("Cloudtrail Create Instance").
 		OfMessage("Unknown source aws_cloudtrail, skipping"))
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_AppendUnknownSource(t *testing.T) {
@@ -2915,7 +2915,7 @@ func TestFalco_Legacy_AppendUnknownSource(t *testing.T) {
 		OfItemName("Rule1").
 		OfMessage("Unknown source mysource, skipping"))
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestFalco_Legacy_NoPluginsUnknownSourceRuleException(t *testing.T) {
@@ -2932,5 +2932,5 @@ func TestFalco_Legacy_NoPluginsUnknownSourceRuleException(t *testing.T) {
 		OfItemName("Cloudtrail Create Instance").
 		OfMessage("Unknown source aws_cloudtrail, skipping"))
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }

--- a/tests/falco/miscs_test.go
+++ b/tests/falco/miscs_test.go
@@ -73,7 +73,7 @@ func TestFalco_Miscs_StartupFail(t *testing.T) {
 	t.Run("empty-config", func(t *testing.T) {
 		res := falco.Test(runner, falco.WithConfig(configs.EmptyConfig))
 		assert.Error(t, res.Err(), "%s", res.Stderr())
-		assert.Equal(t, res.ExitCode(), 1)
+		assert.Equal(t, res.ExitCode(), 1, res.ExitDesc())
 		assert.Contains(t, res.Stderr(), "You must specify at least one rules file")
 	})
 }
@@ -104,7 +104,7 @@ func TestFalco_Miscs_HotReload(t *testing.T) {
 		falco.WithArgs("-o", "engine.kind=nodriver"),
 	)
 	assert.NoError(t, falcoRes.Err(), "%s", falcoRes.Stderr())
-	assert.Equal(t, 0, falcoRes.ExitCode())
+	assert.Zero(t, falcoRes.ExitCode(), falcoRes.ExitDesc())
 	// We want to be sure that the hot reload was triggered
 	assert.Regexp(t, `SIGHUP received, restarting...`, falcoRes.Stderr())
 }
@@ -130,7 +130,7 @@ func TestFalco_Miscs_PrometheusMetricsNoDriver(t *testing.T) {
 		falco.WithArgs("-o", "engine.kind=nodriver"),
 	)
 	assert.NoError(t, falcoRes.Err(), "%s", falcoRes.Stderr())
-	assert.Equal(t, 0, falcoRes.ExitCode())
+	assert.Zero(t, falcoRes.ExitCode(), falcoRes.ExitDesc())
 
 	wg.Wait()
 

--- a/tests/falcoctl/artifact_test.go
+++ b/tests/falcoctl/artifact_test.go
@@ -45,7 +45,7 @@ func TestFalcoctl_Artifact_InstallPlugin(t *testing.T) {
 			falcoctl.WithConfig(run.NewStringFileAccessor("config.yaml", "")),
 		)
 		assert.Error(t, res.Err(), "%s", res.Stdout())
-		assert.NotZero(t, res.ExitCode())
+		assert.NotZero(t, res.ExitCode(), res.ExitDesc())
 		assert.Contains(t, res.Stdout(), "no artifacts to install")
 	})
 
@@ -60,7 +60,7 @@ func TestFalcoctl_Artifact_InstallPlugin(t *testing.T) {
 			falcoctl.WithConfig(run.NewStringFileAccessor("config.yaml", "")),
 		)
 		assert.Error(t, res.Err(), "%s", res.Stdout())
-		assert.NotZero(t, res.ExitCode())
+		assert.NotZero(t, res.ExitCode(), res.ExitDesc())
 		assert.Contains(t, res.Stdout(), "cannot find some_invalid_artifact")
 	})
 
@@ -74,7 +74,7 @@ func TestFalcoctl_Artifact_InstallPlugin(t *testing.T) {
 				falcoctl.WithConfig(run.NewStringFileAccessor("config.yaml", "")),
 			)
 			assert.NoError(t, res.Err(), "%s", res.Stdout()+"\n"+res.Stderr())
-			assert.Zero(t, res.ExitCode())
+			assert.Zero(t, res.ExitCode(), res.ExitDesc())
 			assert.Contains(t, res.Stdout(), "Artifact successfully installed")
 			assert.FileExists(t, sharedWorkDir+"/plugins/libdummy.so")
 		}))
@@ -90,7 +90,7 @@ func TestFalcoctl_Artifact_InstallPlugin(t *testing.T) {
 				falcoctl.WithConfig(run.NewStringFileAccessor("config.yaml", "")),
 			)
 			assert.NoError(t, res.Err(), "%s", res.Stdout()+"\n"+res.Stderr())
-			assert.Zero(t, res.ExitCode())
+			assert.Zero(t, res.ExitCode(), res.ExitDesc())
 			assert.Contains(t, res.Stdout(), "Artifact successfully installed")
 			assert.FileExists(t, sharedWorkDir+"/rulesfiles/aws_cloudtrail_rules.yaml")
 			assert.FileExists(t, sharedWorkDir+"/plugins/libcloudtrail.so")
@@ -108,7 +108,7 @@ func TestFalcoctl_Artifact_InstallPlugin(t *testing.T) {
 				falcoctl.WithConfig(run.NewStringFileAccessor("config.yaml", "")),
 			)
 			require.Nil(t, res.Err(), "%s", res.Stdout())
-			require.Zero(t, res.ExitCode())
+			require.Zero(t, res.ExitCode(), res.ExitDesc())
 
 			// craft a configuration for the plugin
 			config, err := falco.NewPluginConfig(
@@ -137,7 +137,7 @@ func TestFalcoctl_Artifact_InstallPlugin(t *testing.T) {
 				falco.WithEnabledSources("aws_cloudtrail"),
 			)
 			assert.Nil(t, resFalco.Err(), "%s", resFalco.Stderr())
-			assert.Equal(t, 0, resFalco.ExitCode())
+			assert.Zero(t, resFalco.ExitCode(), resFalco.ExitDesc())
 			assert.True(t, resFalco.RuleValidation().At(0).Successful)
 			assert.Zero(t, resFalco.RuleValidation().AllWarnings().Count())
 		}))
@@ -158,7 +158,7 @@ func TestFalcoctl_Artifact_Info(t *testing.T) {
 			falcoctl.WithConfig(run.NewStringFileAccessor("config.yaml", "")),
 		)
 		assert.Error(t, res.Err(), "%s", res.Stderr())
-		assert.NotZero(t, res.ExitCode())
+		assert.NotZero(t, res.ExitCode(), res.ExitDesc())
 		assert.Contains(t, res.Stdout(), "requires at least 1 arg(s), only received 0")
 	})
 
@@ -174,7 +174,7 @@ func TestFalcoctl_Artifact_Info(t *testing.T) {
 				falcoctl.WithConfig(run.NewStringFileAccessor("config.yaml", "")),
 			)
 			assert.NoError(t, res.Err(), "%s", res.Stdout()+"\n"+res.Stderr())
-			assert.Zero(t, res.ExitCode())
+			assert.Zero(t, res.ExitCode(), res.ExitDesc())
 			assert.Regexp(t, `.*REF[\s]+TAGS.*`, res.Stdout())
 			assert.Regexp(t, `.*ghcr.io\/falcosecurity\/plugins\/plugin\/dummy[\s]*(latest[\s]*,[\s]*)?[\s]+([0-9]+(.[0-9]+)?(.[0-9]+)?[\s]*,[\s]*)+[\s]*(latest)?.*`, res.Stdout())
 			assert.NoFileExists(t, sharedWorkDir+"/plugins/libdummy.so")
@@ -193,7 +193,7 @@ func TestFalcoctl_Artifact_Info(t *testing.T) {
 				falcoctl.WithConfig(run.NewStringFileAccessor("config.yaml", "")),
 			)
 			assert.NoError(t, res.Err(), "%s", res.Stdout()+"\n"+res.Stderr())
-			assert.Zero(t, res.ExitCode())
+			assert.Zero(t, res.ExitCode(), res.ExitDesc())
 			assert.Regexp(t, `.*REF[\s]+TAGS.*`, res.Stdout())
 			assert.Regexp(t, `.*ghcr.io\/falcosecurity\/plugins\/ruleset\/cloudtrail[\s]*(latest[\s]*,[\s]*)?[\s]+([0-9]+(.[0-9]+)?(.[0-9]+)?[\s]*,[\s]*)+[\s]*(latest)?.*`, res.Stdout())
 			assert.NoFileExists(t, sharedWorkDir+"/plugins/libcloudtrail.so")
@@ -217,7 +217,7 @@ func TestFalcoctl_Artifact_List(t *testing.T) {
 				falcoctl.WithConfig(run.NewStringFileAccessor("config.yaml", "")),
 			)
 			assert.NoError(t, res.Err(), "%s", res.Stdout()+"\n"+res.Stderr())
-			assert.Zero(t, res.ExitCode())
+			assert.Zero(t, res.ExitCode(), res.ExitDesc())
 			assert.GreaterOrEqual(t, len(strings.Split(res.Stdout(), "\n")), 2)
 			assert.Regexp(t, `.*INDEX[\s]+ARTIFACT[\s]+TYPE[\s]+REGISTRY[\s]+REPOSITORY.*`, res.Stdout())
 			assert.Regexp(t, `.*falcosecurity[\s]+dummy[\s]+plugin[\s]+ghcr.io[\s]+falcosecurity/plugins/plugin/dummy.*`, res.Stdout())
@@ -236,7 +236,7 @@ func TestFalcoctl_Artifact_List(t *testing.T) {
 				falcoctl.WithConfig(run.NewStringFileAccessor("config.yaml", "")),
 			)
 			assert.NoError(t, res.Err(), "%s", res.Stdout()+"\n"+res.Stderr())
-			assert.Zero(t, res.ExitCode())
+			assert.Zero(t, res.ExitCode(), res.ExitDesc())
 			assert.GreaterOrEqual(t, len(strings.Split(res.Stdout(), "\n")), 2)
 			assert.Regexp(t, `.*INDEX[\s]+ARTIFACT[\s]+TYPE[\s]+REGISTRY[\s]+REPOSITORY.*`, res.Stdout())
 			assert.Regexp(t, `.*falcosecurity[\s]+dummy[\s]+plugin[\s]+ghcr.io[\s]+falcosecurity/plugins/plugin/dummy.*`, res.Stdout())
@@ -256,7 +256,7 @@ func TestFalcoctl_Artifact_List(t *testing.T) {
 				falcoctl.WithConfig(run.NewStringFileAccessor("config.yaml", "")),
 			)
 			assert.NoError(t, res.Err(), "%s", res.Stdout()+"\n"+res.Stderr())
-			assert.Zero(t, res.ExitCode())
+			assert.Zero(t, res.ExitCode(), res.ExitDesc())
 			assert.GreaterOrEqual(t, len(strings.Split(res.Stdout(), "\n")), 2)
 			assert.Regexp(t, `.*INDEX[\s]+ARTIFACT[\s]+TYPE[\s]+REGISTRY[\s]+REPOSITORY.*`, res.Stdout())
 			assert.Regexp(t, `.*falcosecurity[\s]+cloudtrail-rules[\s]+rulesfile[\s]+ghcr.io[\s]+falcosecurity/plugins/ruleset/cloudtrail.*`, res.Stdout())
@@ -279,7 +279,7 @@ func TestFalcoctl_Artifact_Search(t *testing.T) {
 			falcoctl.WithConfig(run.NewStringFileAccessor("config.yaml", "")),
 		)
 		assert.Error(t, res.Err(), "%s", res.Stderr())
-		assert.NotZero(t, res.ExitCode())
+		assert.NotZero(t, res.ExitCode(), res.ExitDesc())
 		assert.Contains(t, res.Stdout(), "requires at least 1 arg(s), only received 0")
 	})
 
@@ -294,7 +294,7 @@ func TestFalcoctl_Artifact_Search(t *testing.T) {
 				falcoctl.WithConfig(run.NewStringFileAccessor("config.yaml", "")),
 			)
 			assert.NoError(t, res.Err(), "%s", res.Stdout()+"\n"+res.Stderr())
-			assert.Zero(t, res.ExitCode())
+			assert.Zero(t, res.ExitCode(), res.ExitDesc())
 			assert.Regexp(t, `.*INDEX[\s]+ARTIFACT[\s]+TYPE[\s]+REGISTRY[\s]+REPOSITORY.*`, res.Stdout())
 			assert.Regexp(t, `.*falcosecurity[\s]+dummy[\s]+plugin[\s]+ghcr.io[\s]+falcosecurity/plugins/plugin/dummy.*`, res.Stdout())
 			assert.Regexp(t, `.*falcosecurity[\s]+dummy_c[\s]+plugin[\s]+ghcr.io[\s]+falcosecurity/plugins/plugin/dummy_c.*`, res.Stdout())
@@ -314,7 +314,7 @@ func TestFalcoctl_Artifact_Search(t *testing.T) {
 				falcoctl.WithConfig(run.NewStringFileAccessor("config.yaml", "")),
 			)
 			assert.NoError(t, res.Err(), "%s", res.Stdout()+"\n"+res.Stderr())
-			assert.Zero(t, res.ExitCode())
+			assert.Zero(t, res.ExitCode(), res.ExitDesc())
 			assert.Regexp(t, `.*INDEX[\s]+ARTIFACT[\s]+TYPE[\s]+REGISTRY[\s]+REPOSITORY.*`, res.Stdout())
 			assert.Regexp(t, `.*falcosecurity[\s]+dummy[\s]+plugin[\s]+ghcr.io[\s]+falcosecurity/plugins/plugin/dummy.*`, res.Stdout())
 			assert.Regexp(t, `.*falcosecurity[\s]+dummy_c[\s]+plugin[\s]+ghcr.io[\s]+falcosecurity/plugins/plugin/dummy_c.*`, res.Stdout())
@@ -341,8 +341,8 @@ func TestFalcoctl_Artifact_Search(t *testing.T) {
 		)
 		assert.Nil(t, resList.Err(), "%s", resList.Stdout())
 		assert.Nil(t, resSearch.Err(), "%s", resSearch.Stdout())
-		assert.Zero(t, resList.ExitCode())
-		assert.Zero(t, resSearch.ExitCode())
+		assert.Zero(t, resList.ExitCode(), resList.ExitDesc())
+		assert.Zero(t, resSearch.ExitCode(), resSearch.ExitDesc())
 		listLines := strings.Split(resSearch.Stdout(), "\n")
 		searchLines := strings.Split(resSearch.Stdout(), "\n")
 		for _, line := range listLines {

--- a/tests/falcoctl/version_test.go
+++ b/tests/falcoctl/version_test.go
@@ -40,7 +40,7 @@ func TestFalcoctl_Version(t *testing.T) {
 			falcoctl.WithArgs("version", "some_other_cmd"),
 		)
 		assert.Error(t, res.Err(), "%s", res.Stderr())
-		assert.NotZero(t, res.ExitCode())
+		assert.NotZero(t, res.ExitCode(), res.ExitDesc())
 		assert.Contains(t, res.Stdout(), `unknown command "some_other_cmd"`)
 	})
 
@@ -51,7 +51,7 @@ func TestFalcoctl_Version(t *testing.T) {
 			falcoctl.WithArgs("version"),
 		)
 		assert.NoError(t, res.Err(), "%s", res.Stderr())
-		assert.Zero(t, res.ExitCode())
+		assert.Zero(t, res.ExitCode(), res.ExitDesc())
 		assert.Regexp(t, `Client Version:[\s]+[0-9]+.[0-9]+.[0-9]+(-[a-z]+[0-9]+)?`, res.Stdout())
 	})
 
@@ -62,7 +62,7 @@ func TestFalcoctl_Version(t *testing.T) {
 			falcoctl.WithArgs("version", "--output=json"),
 		)
 		assert.NoError(t, res.Err(), "%s", res.Stderr())
-		assert.Equal(t, res.ExitCode(), 0)
+		assert.Zero(t, res.ExitCode(), res.ExitDesc())
 		out := make(map[string]interface{})
 		require.Nil(t, json.Unmarshal([]byte(res.Stdout()[strings.Index(res.Stdout(), "{"):]), &out))
 		assert.Contains(t, out, "semVersion")
@@ -80,7 +80,7 @@ func TestFalcoctl_Version(t *testing.T) {
 			falcoctl.WithArgs("version", "--output=yaml"),
 		)
 		assert.NoError(t, res.Err(), "%s", res.Stderr())
-		assert.Equal(t, res.ExitCode(), 0)
+		assert.Zero(t, res.ExitCode(), res.ExitDesc())
 		out := make(map[string]interface{})
 		require.Nil(t, yaml.Unmarshal([]byte(res.Stdout()[strings.Index(res.Stdout(), ":\n")+1:]), &out))
 		assert.Contains(t, out, "semversion")

--- a/tests/falcodriverloader/drivers_test.go
+++ b/tests/falcodriverloader/drivers_test.go
@@ -46,7 +46,7 @@ func TestFalcoKmod(t *testing.T) {
 		falcoctl.WithArgs("driver", "install", "--download=false", "--type", "kmod"),
 	)
 	assert.NoError(t, loaderRes.Err(), "%s", loaderRes.Stderr())
-	assert.Equal(t, 0, loaderRes.ExitCode())
+	assert.Zero(t, loaderRes.ExitCode(), loaderRes.ExitDesc())
 	// We expect the module to be loaded in dkms
 	assert.Regexp(t, `kernel module available.`, loaderRes.Stdout())
 
@@ -57,7 +57,7 @@ func TestFalcoKmod(t *testing.T) {
 		falco.WithArgs("-o", "engine.kind=kmod"),
 	)
 	assert.NoError(t, falcoRes.Err(), "%s", falcoRes.Stderr())
-	assert.Equal(t, 0, falcoRes.ExitCode())
+	assert.Zero(t, falcoRes.ExitCode(), falcoRes.ExitDesc())
 	// We want to be sure to run the Kernel module.
 	assert.Regexp(t, `source with Kernel module`, falcoRes.Stderr())
 	// We want to be sure that the engine is correctly opened.
@@ -74,7 +74,7 @@ func TestFalcoModernBpf(t *testing.T) {
 		falco.WithArgs("-o", "engine.kind=modern_ebpf"),
 	)
 	assert.NoError(t, falcoRes.Err(), "%s", falcoRes.Stderr())
-	assert.Equal(t, 0, falcoRes.ExitCode())
+	assert.Zero(t, falcoRes.ExitCode(), falcoRes.ExitDesc())
 	// We want to be sure to run the Kernel module.
 	assert.Regexp(t, `source with modern BPF probe`, falcoRes.Stderr())
 	// We want to be sure that the engine is correctly opened.

--- a/tests/k8saudit/k8saudit_test.go
+++ b/tests/k8saudit/k8saudit_test.go
@@ -73,7 +73,7 @@ func TestK8SAudit_Legacy_CreateSensitiveMountPod(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("Create Sensitive Mount Pod").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreateService(t *testing.T) {
@@ -90,7 +90,7 @@ func TestK8SAudit_Legacy_CreateService(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("INFO").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("K8s Service Created").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_DeleteConfigmap(t *testing.T) {
@@ -107,7 +107,7 @@ func TestK8SAudit_Legacy_DeleteConfigmap(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("INFO").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("K8s ConfigMap Deleted").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreateNamespace(t *testing.T) {
@@ -126,7 +126,7 @@ func TestK8SAudit_Legacy_CreateNamespace(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("INFO").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("K8s Namespace Created").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_DeleteDeployment(t *testing.T) {
@@ -143,7 +143,7 @@ func TestK8SAudit_Legacy_DeleteDeployment(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("INFO").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("K8s Deployment Deleted").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_DeleteClusterrolebinding(t *testing.T) {
@@ -160,7 +160,7 @@ func TestK8SAudit_Legacy_DeleteClusterrolebinding(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("INFO").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("K8s ClusterRoleBinding Deleted").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CompatEngineV4CreateDisallowedPod(t *testing.T) {
@@ -178,7 +178,7 @@ func TestK8SAudit_Legacy_CompatEngineV4CreateDisallowedPod(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("Create Disallowed Pod").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CompatEngineV4CreateHostnetworkPod(t *testing.T) {
@@ -195,7 +195,7 @@ func TestK8SAudit_Legacy_CompatEngineV4CreateHostnetworkPod(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("Create HostNetwork Pod").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreatePodExecClusterRole(t *testing.T) {
@@ -212,7 +212,7 @@ func TestK8SAudit_Legacy_CreatePodExecClusterRole(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("ClusterRole With Pod Exec Created").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreateConfigmap(t *testing.T) {
@@ -229,7 +229,7 @@ func TestK8SAudit_Legacy_CreateConfigmap(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("INFO").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("K8s ConfigMap Created").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CompatEngineV4CreatePrivilegedPod(t *testing.T) {
@@ -246,7 +246,7 @@ func TestK8SAudit_Legacy_CompatEngineV4CreatePrivilegedPod(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("Create Privileged Pod").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_NamespaceInAllowedSet(t *testing.T) {
@@ -261,7 +261,7 @@ func TestK8SAudit_Legacy_NamespaceInAllowedSet(t *testing.T) {
 			rules.K8SAuditDisallowKactivity),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreateServiceaccountInKubePublicNamespace(t *testing.T) {
@@ -278,7 +278,7 @@ func TestK8SAudit_Legacy_CreateServiceaccountInKubePublicNamespace(t *testing.T)
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("Service Account Created in Kube Namespace").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreateDeployment(t *testing.T) {
@@ -295,7 +295,7 @@ func TestK8SAudit_Legacy_CreateDeployment(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("INFO").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("K8s Deployment Created").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_DeleteNamespace(t *testing.T) {
@@ -312,7 +312,7 @@ func TestK8SAudit_Legacy_DeleteNamespace(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("INFO").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("K8s Namespace Deleted").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_JsonPointerCorrectParse(t *testing.T) {
@@ -327,7 +327,7 @@ func TestK8SAudit_Legacy_JsonPointerCorrectParse(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("json_pointer_example").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreateDisallowedPod(t *testing.T) {
@@ -345,7 +345,7 @@ func TestK8SAudit_Legacy_CreateDisallowedPod(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("Create Disallowed Pod").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreateNohostnetworkPod(t *testing.T) {
@@ -358,7 +358,7 @@ func TestK8SAudit_Legacy_CreateNohostnetworkPod(t *testing.T) {
 			rules.K8SAuditRules),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreateNonodeportService(t *testing.T) {
@@ -372,7 +372,7 @@ func TestK8SAudit_Legacy_CreateNonodeportService(t *testing.T) {
 			rules.K8SAuditDisallowKactivity),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreatePodInKubePublicNamespace(t *testing.T) {
@@ -389,7 +389,7 @@ func TestK8SAudit_Legacy_CreatePodInKubePublicNamespace(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("Pod Created in Kube Namespace").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreateClusterRoleWildcardResources(t *testing.T) {
@@ -406,7 +406,7 @@ func TestK8SAudit_Legacy_CreateClusterRoleWildcardResources(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("ClusterRole With Wildcard Created").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_SystemClusterroleDeleted(t *testing.T) {
@@ -423,7 +423,7 @@ func TestK8SAudit_Legacy_SystemClusterroleDeleted(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("System ClusterRole Modified/Deleted").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CompatEngineV4CreateAllowedPod(t *testing.T) {
@@ -437,7 +437,7 @@ func TestK8SAudit_Legacy_CompatEngineV4CreateAllowedPod(t *testing.T) {
 			rules.K8SAuditEngineV4AllowNginxContainer),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CompatEngineV4CreatePrivilegedTrustedPod(t *testing.T) {
@@ -452,7 +452,7 @@ func TestK8SAudit_Legacy_CompatEngineV4CreatePrivilegedTrustedPod(t *testing.T) 
 			rules.K8SAuditTrustNginxContainer),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreateUnsensitiveMountPod(t *testing.T) {
@@ -465,7 +465,7 @@ func TestK8SAudit_Legacy_CreateUnsensitiveMountPod(t *testing.T) {
 			rules.K8SAuditRules),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreateNodeportService(t *testing.T) {
@@ -483,7 +483,7 @@ func TestK8SAudit_Legacy_CreateNodeportService(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("Create NodePort Service").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_NamespaceOutsideAllowedSet(t *testing.T) {
@@ -501,7 +501,7 @@ func TestK8SAudit_Legacy_NamespaceOutsideAllowedSet(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("Create Disallowed Namespace").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_DeleteSecret(t *testing.T) {
@@ -518,7 +518,7 @@ func TestK8SAudit_Legacy_DeleteSecret(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("INFO").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("K8s Secret Deleted").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreateSensitiveMountTrustedPod(t *testing.T) {
@@ -532,7 +532,7 @@ func TestK8SAudit_Legacy_CreateSensitiveMountTrustedPod(t *testing.T) {
 			rules.K8SAuditTrustNginxContainer),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_PodExec(t *testing.T) {
@@ -549,7 +549,7 @@ func TestK8SAudit_Legacy_PodExec(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("NOTICE").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("Attach/Exec Pod").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_PodAttach(t *testing.T) {
@@ -566,7 +566,7 @@ func TestK8SAudit_Legacy_PodAttach(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("NOTICE").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("Attach/Exec Pod").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreateServiceaccountInKubeSystemNamespace(t *testing.T) {
@@ -583,7 +583,7 @@ func TestK8SAudit_Legacy_CreateServiceaccountInKubeSystemNamespace(t *testing.T)
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("Service Account Created in Kube Namespace").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_AttachClusterAdminRole(t *testing.T) {
@@ -600,7 +600,7 @@ func TestK8SAudit_Legacy_AttachClusterAdminRole(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("Attach to cluster-admin Role").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CompatEngineV4CreateUnprivilegedPod(t *testing.T) {
@@ -613,7 +613,7 @@ func TestK8SAudit_Legacy_CompatEngineV4CreateUnprivilegedPod(t *testing.T) {
 			rules.K8SAuditEngineV4K8SAuditRules),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreatePrivilegedNoSecctx1StContainer2NdContainerPod(t *testing.T) {
@@ -630,7 +630,7 @@ func TestK8SAudit_Legacy_CreatePrivilegedNoSecctx1StContainer2NdContainerPod(t *
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("Create Privileged Pod").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreateUnsensitiveMountTrustedPod(t *testing.T) {
@@ -644,7 +644,7 @@ func TestK8SAudit_Legacy_CreateUnsensitiveMountTrustedPod(t *testing.T) {
 			rules.K8SAuditTrustNginxContainer),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreatePrivileged2NdContainerPod(t *testing.T) {
@@ -661,7 +661,7 @@ func TestK8SAudit_Legacy_CreatePrivileged2NdContainerPod(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("Create Privileged Pod").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreateHostnetworkTrustedPod(t *testing.T) {
@@ -675,7 +675,7 @@ func TestK8SAudit_Legacy_CreateHostnetworkTrustedPod(t *testing.T) {
 			rules.K8SAuditTrustNginxContainer),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreateServiceaccount(t *testing.T) {
@@ -692,7 +692,7 @@ func TestK8SAudit_Legacy_CreateServiceaccount(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("INFO").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("K8s Serviceaccount Created").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreateKubeSystemSecret(t *testing.T) {
@@ -708,7 +708,7 @@ func TestK8SAudit_Legacy_CreateKubeSystemSecret(t *testing.T) {
 	assert.Zero(t, res.Detections().Count())
 	assert.Zero(t, res.Detections().OfPriority("INFO").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_UserInAllowedSet(t *testing.T) {
@@ -724,7 +724,7 @@ func TestK8SAudit_Legacy_UserInAllowedSet(t *testing.T) {
 			rules.K8SAuditDisallowKactivity),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreateClusterRoleWildcardVerbs(t *testing.T) {
@@ -741,7 +741,7 @@ func TestK8SAudit_Legacy_CreateClusterRoleWildcardVerbs(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("ClusterRole With Wildcard Created").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreateWritableClusterRole(t *testing.T) {
@@ -758,7 +758,7 @@ func TestK8SAudit_Legacy_CreateWritableClusterRole(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("NOTICE").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("ClusterRole With Write Privileges Created").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_DeleteClusterrole(t *testing.T) {
@@ -775,7 +775,7 @@ func TestK8SAudit_Legacy_DeleteClusterrole(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("INFO").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("K8s ClusterRole Deleted").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreateSecret(t *testing.T) {
@@ -792,7 +792,7 @@ func TestK8SAudit_Legacy_CreateSecret(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("INFO").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("K8s Secret Created").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CompatEngineV4CreateHostnetworkTrustedPod(t *testing.T) {
@@ -807,7 +807,7 @@ func TestK8SAudit_Legacy_CompatEngineV4CreateHostnetworkTrustedPod(t *testing.T)
 			rules.K8SAuditTrustNginxContainer),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreateSensitiveMount2NdContainerPod(t *testing.T) {
@@ -824,7 +824,7 @@ func TestK8SAudit_Legacy_CreateSensitiveMount2NdContainerPod(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("Create Sensitive Mount Pod").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_DeleteServiceaccount(t *testing.T) {
@@ -841,7 +841,7 @@ func TestK8SAudit_Legacy_DeleteServiceaccount(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("INFO").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("K8s Serviceaccount Deleted").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreateClusterrole(t *testing.T) {
@@ -858,7 +858,7 @@ func TestK8SAudit_Legacy_CreateClusterrole(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("INFO").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("K8s ClusterRole Created").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreateClusterrolebinding(t *testing.T) {
@@ -875,7 +875,7 @@ func TestK8SAudit_Legacy_CreateClusterrolebinding(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("INFO").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("K8s ClusterRoleBinding Created").Count(), res.Stdout())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreateAllowedPod(t *testing.T) {
@@ -889,7 +889,7 @@ func TestK8SAudit_Legacy_CreateAllowedPod(t *testing.T) {
 			rules.K8SAuditAllowNginxContainer),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreateUnprivilegedTrustedPod(t *testing.T) {
@@ -903,7 +903,7 @@ func TestK8SAudit_Legacy_CreateUnprivilegedTrustedPod(t *testing.T) {
 			rules.K8SAuditTrustNginxContainer),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreateNohostnetworkTrustedPod(t *testing.T) {
@@ -917,7 +917,7 @@ func TestK8SAudit_Legacy_CreateNohostnetworkTrustedPod(t *testing.T) {
 			rules.K8SAuditTrustNginxContainer),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreatePrivilegedPod(t *testing.T) {
@@ -934,7 +934,7 @@ func TestK8SAudit_Legacy_CreatePrivilegedPod(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("Create Privileged Pod").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreateConfigmapPrivateCreds(t *testing.T) {
@@ -952,7 +952,7 @@ func TestK8SAudit_Legacy_CreateConfigmapPrivateCreds(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.Equal(t, 6, res.Detections().OfRule("Create/Modify Configmap With Private Credentials").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreateConfigmapNoPrivateCreds(t *testing.T) {
@@ -966,7 +966,7 @@ func TestK8SAudit_Legacy_CreateConfigmapNoPrivateCreds(t *testing.T) {
 			rules.K8SAuditDisallowKactivity),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreatePrivilegedTrustedPod(t *testing.T) {
@@ -980,7 +980,7 @@ func TestK8SAudit_Legacy_CreatePrivilegedTrustedPod(t *testing.T) {
 			rules.K8SAuditTrustNginxContainer),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreateHostnetworkPod(t *testing.T) {
@@ -997,7 +997,7 @@ func TestK8SAudit_Legacy_CreateHostnetworkPod(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("Create HostNetwork Pod").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_AnonymousUser(t *testing.T) {
@@ -1014,7 +1014,7 @@ func TestK8SAudit_Legacy_AnonymousUser(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("Anonymous Request Allowed").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_SystemClusterroleModified(t *testing.T) {
@@ -1031,7 +1031,7 @@ func TestK8SAudit_Legacy_SystemClusterroleModified(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("System ClusterRole Modified/Deleted").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_Fal01003(t *testing.T) {
@@ -1045,7 +1045,7 @@ func TestK8SAudit_Legacy_Fal01003(t *testing.T) {
 	)
 	assert.Regexp(t, `data not recognized as a k8s audit event`, res.Stderr())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_UserOutsideAllowedSet(t *testing.T) {
@@ -1063,7 +1063,7 @@ func TestK8SAudit_Legacy_UserOutsideAllowedSet(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("Disallowed K8s User").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreateUnprivilegedPod(t *testing.T) {
@@ -1076,7 +1076,7 @@ func TestK8SAudit_Legacy_CreateUnprivilegedPod(t *testing.T) {
 			rules.K8SAuditRules),
 	)
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreatePodInKubeSystemNamespace(t *testing.T) {
@@ -1093,7 +1093,7 @@ func TestK8SAudit_Legacy_CreatePodInKubeSystemNamespace(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("WARNING").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("Pod Created in Kube Namespace").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_DeleteService(t *testing.T) {
@@ -1110,7 +1110,7 @@ func TestK8SAudit_Legacy_DeleteService(t *testing.T) {
 	assert.NotZero(t, res.Detections().OfPriority("INFO").Count())
 	assert.Equal(t, 1, res.Detections().OfRule("K8s Service Deleted").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }
 
 func TestK8SAudit_Legacy_CreateServiceAccountTokenSecret(t *testing.T) {
@@ -1126,5 +1126,5 @@ func TestK8SAudit_Legacy_CreateServiceAccountTokenSecret(t *testing.T) {
 	assert.Zero(t, res.Detections().Count())
 	assert.Zero(t, res.Detections().OfPriority("INFO").Count())
 	assert.NoError(t, res.Err(), "%s", res.Stderr())
-	assert.Equal(t, 0, res.ExitCode())
+	assert.Zero(t, res.ExitCode(), res.ExitDesc())
 }


### PR DESCRIPTION
When Falco or Falcoctl processes crash, assertions just print something like "exit code -1". -1 is obviously not the exit code, but the value returned by `exec.ExitError.ProcessState.ExitCode()` when called on a process that crashed. In order to have better visibility on the crash reason, this PR exposes an additional `Desc` containing the reason of the crash, and prints it when an assertion on the exit code fails.