### PR TITLE
chore(action.yaml): drop hard-coded architecture in report suffix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,3 +52,4 @@ jobs:
           test-dummy: 'true'
           show-all: 'true'
           sudo: ''
+          report-name-suffix: "${{matrix.arch}}"

--- a/action.yml
+++ b/action.yml
@@ -131,7 +131,7 @@ runs:
       if: always() # note: upload the report even if tests fail
       uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       with:
-        name: falcosecurity-testing-report-${{ runner.arch }}${{ inputs.report-name-suffix }}
+        name: falcosecurity-testing-report-${{ inputs.report-name-suffix }}
         path: |
           ${{ steps.store-outputs.outputs.report }}
           ${{ steps.store-outputs.outputs.report_txt }}


### PR DESCRIPTION
This PR lets the action user decide if it wants to append the architecture in report suffix. This requires an upcoming PR in falco to re-include it.

**EDIT**

Falco PR: https://github.com/falcosecurity/falco/pull/3859