### PR TITLE
docs(OWNERS): moving `andreagit97` to emeritus

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,6 @@
 approvers:
   - jasondellaluce
   - leogr
-  - andreagit97
   - lucaguerra
+emeritus_approvers:
+  - andreagit97


### PR DESCRIPTION
**What this PR does / why we need it**:

This moves @Andreagit97 from `approvers` to `emeritus_approvers`, as per his request in falcosecurity/evolution#526.

Thank you for everything, Andrea! 🙏 It won't be the same without you around here, and you're always welcome back.

**Which issue(s) this PR fixes**:

Part of the step-down tracked in falcosecurity/evolution#526 (not closing it here, since it spans multiple repositories).

**Special notes for your reviewer**:

Since this is a voluntary step-down, no vote is required - we can merge by [lazy consensus](https://github.com/falcosecurity/evolution/blob/main/GOVERNANCE.md#maintainership).

/kind documentation

cc @falcosecurity/core-maintainers
